### PR TITLE
Remove use of deprecated Django functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
   - ./.travis_setup
 
 env:
-  - DJANGO="Django>=1.4,<1.5" EASY_THUMBNAILS="easy-thumbnails>=1.2,<2.0"
   - DJANGO="Django>=1.5,<1.6" EASY_THUMBNAILS="easy-thumbnails>=1.4,<2.0"
   - DJANGO="Django>=1.6,<1.7" EASY_THUMBNAILS="easy-thumbnails>=1.4,<2.0"
   - DJANGO="Django>=1.6,<1.7" EASY_THUMBNAILS="easy-thumbnails>2.0"
@@ -41,10 +40,6 @@ matrix:
       env: DJANGO="Django>=1.8,<1.9" EASY_THUMBNAILS="easy-thumbnails>2.0" CUSTOM_IMAGE="filer.test_utils.custom_image.models.Image"
     - python: 2.6
       env: DJANGO="https://github.com/django/django/archive/master.zip" EASY_THUMBNAILS="easy-thumbnails>2.0"
-    - python: 3.3
-      env: DJANGO="Django>=1.4,<1.5" EASY_THUMBNAILS="easy-thumbnails>=1.2,<2.0"
-    - python: 3.4
-      env: DJANGO="Django>=1.4,<1.5" EASY_THUMBNAILS="easy-thumbnails>=1.2,<2.0"
   allow_failures:
     - python: 2.7
       env: DJANGO="https://github.com/django/django/archive/master.zip" EASY_THUMBNAILS="easy-thumbnails>2.0"

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Wiki: https://github.com/stefanfoulis/django-filer/wiki
 Dependencies
 ------------
 
-* `Django`_ >= 1.4
+* `Django`_ >= 1.5
 * `django-mptt`_ >=0.5.1
 * `easy_thumbnails`_ >= 1.0
 * `django-polymorphic`_ >= 0.2

--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -1,13 +1,12 @@
 #-*- coding: utf-8 -*-
 from django import forms
-from django.contrib.admin.util import unquote
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
 from filer import settings
 from filer.admin.permissions import PrimitivePermissionAwareModelAdmin
 from filer.models import File, Image
-from filer.utils.compatibility import DJANGO_1_5
+from filer.utils.compatibility import DJANGO_1_5, unquote
 from filer.views import (popup_param, selectfolder_param, popup_status,
                          selectfolder_status)
 

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -8,7 +8,6 @@ from django import forms
 from django.conf import settings as django_settings
 from django.contrib import messages
 from django.contrib.admin import helpers
-from django.contrib.admin.util import quote, unquote, capfirst
 from django.core.exceptions import ValidationError
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -43,7 +42,7 @@ from filer.models import (Folder, FolderRoot, UnfiledImages, File, tools,
                           ImagesWithMissingData, FolderPermission, Image)
 from filer.settings import FILER_STATICMEDIA_PREFIX, FILER_PAGINATE_BY
 from filer.thumbnail_processors import normalize_subject_location
-from filer.utils.compatibility import get_delete_permission
+from filer.utils.compatibility import get_delete_permission, quote, unquote, capfirst
 from filer.utils.filer_easy_thumbnails import FilerActionThumbnailer
 from filer.views import (popup_status, popup_param, selectfolder_status,
                          selectfolder_param)

--- a/filer/admin/patched/admin_utils.py
+++ b/filer/admin/patched/admin_utils.py
@@ -10,7 +10,6 @@ At all locations where something has been changed, there are inline comments in 
 """
 from __future__ import unicode_literals
 
-from django.contrib.admin.util import NestedObjects, quote
 from django.core.urlresolvers import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
@@ -21,7 +20,7 @@ except ImportError:
     # Django < 1.5
     from django.utils.encoding import force_unicode as force_text
 
-from filer.utils.compatibility import get_delete_permission
+from filer.utils.compatibility import get_delete_permission, NestedObjects, quote
 
 
 def get_deleted_objects(objs, opts, user, admin_site, using):

--- a/filer/templates/admin/filer/breadcrumbs.html
+++ b/filer/templates/admin/filer/breadcrumbs.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 <div class="breadcrumbs">
    <a href="{% url 'admin:index' %}" title="{% trans "Go back to admin homepage" %}">{% trans "Home" %}</a>
     &rsaquo; <a href="{% url 'admin:app_list' app_label='filer' %}" title="{% trans "Go back to Filer app" %}"> {% trans "Filer" %}</a>

--- a/filer/templates/admin/filer/delete_confirmation.html
+++ b/filer/templates/admin/filer/delete_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/delete_confirmation.html" %}
 {% load i18n filermedia %}
-{% load url from future %}
 
 {% block extrastyle %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% filer_staticmedia_prefix %}css/admin_style.css" />

--- a/filer/templates/admin/filer/folder/change_form.html
+++ b/filer/templates/admin/filer/folder/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_modify filermedia %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -1,15 +1,12 @@
 {% extends "admin/filer/base_site.html" %}
 {% load filer_admin_tags filermedia i18n %}
-{% load url from future %}
 
 {% block extrahead %}{{ block.super }}
 {# upload stuff #}
 {{ media.js }}
-<script type="text/javascript" src="{% admin_js_base %}jquery.min.js"></script>
 <script type="text/javascript" src="{% filer_staticmedia_prefix %}js/jquery.cookie.js"></script>
 <script type="text/javascript" src="{% filer_staticmedia_prefix %}js/fileuploader.js"></script>
 <script type="text/javascript" src="{% filer_staticmedia_prefix %}js/retina.js"></script>
-<script type="text/javascript" src="{% admin_js_base %}admin/RelatedObjectLookups.js"></script>
 <script type="text/javascript" src="{% filer_staticmedia_prefix %}js/popup_handling.js"></script>
 {% if action_form %}{% if actions_on_top or actions_on_bottom %}
 <script type="text/javascript">

--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -1,6 +1,5 @@
 {% load i18n l10n %}
 {% load admin_list filermedia filer_tags %}
-{% load url from future %}
 
 <div id="toolbartable">
     <table cellspacing="0">

--- a/filer/templates/admin/filer/tools/clipboard/clipboard.html
+++ b/filer/templates/admin/filer/tools/clipboard/clipboard.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 
 {% for clipboard in user.filer_clipboards.all %}
 <table style="width: 100%; border: 1px solid #DDDDDD;" class="clipboard">

--- a/filer/templates/admin/filer/tools/upload_button_js.html
+++ b/filer/templates/admin/filer/tools/upload_button_js.html
@@ -1,5 +1,4 @@
 {% load i18n admin_modify filermedia %}
-{% load url from future %}
 
 <script type="text/javascript">
 //<![CDATA[

--- a/filer/utils/compatibility.py
+++ b/filer/utils/compatibility.py
@@ -63,3 +63,15 @@ def get_delete_permission(opts):
     except ImportError:
         return '%s.%s' % (opts.app_label,
                           opts.get_delete_permission())
+
+try:
+    from django.contrib.admin.utils import unquote, quote, NestedObjects, capfirst
+except ImportError:
+    # django < 1.7
+    from django.contrib.admin.util import unquote, quote, NestedObjects, capfirst
+
+try:
+    from importlib import import_module
+except ImportError:
+    # python < 2.7
+    from django.utils.importlib import import_module

--- a/filer/utils/loader.py
+++ b/filer/utils/loader.py
@@ -9,7 +9,7 @@ local changes:
 
 """
 from django.utils import six
-from django.utils.importlib import import_module
+from filer.utils.compatibility import import_module
 
 
 def load_object(import_path):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email = 'stefan@foulis.ch',
     packages=find_packages(),
     install_requires = (
-        'Django>=1.4',
+        'Django>=1.5',
         'easy-thumbnails>=1.0',
         'django-mptt>=0.6',
         'django_polymorphic>=0.7',


### PR DESCRIPTION
All this stuff has deprecated for a long time, and is getting removed in Django 1.9.