### PR TITLE
Give user hint about why the clipboard arrow is grey and disabled

### DIFF
--- a/filer/templates/admin/filer/tools/clipboard/clipboard.html
+++ b/filer/templates/admin/filer/tools/clipboard/clipboard.html
@@ -16,7 +16,7 @@
                     <input type="hidden" name="redirect_to" value="{{ current_url }}" />
                     {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
                     {% if select_folder %}<input type="hidden" name="select_folder" value="1" />{% endif %}
-                    <input type="submit" value="&lArr;"{% if folder.is_root or not permissions.has_add_children_permission %} disabled="disabled" style="color: gray;"{% endif %} title="{% trans "Paste all items here" %}"/>
+                    <input type="submit" value="&lArr;"{% if folder.is_root or not permissions.has_add_children_permission %} disabled="disabled" style="color: gray;" title="{% trans "You do not have permission to put files in this folder" %}"{% endif %} title="{% trans "Paste all items here" %}"/>
                 </form>
                 <form action="{% url 'admin:filer-discard_clipboard' %}" method="post"  style="display: inline;">{% csrf_token %}
                     <input type="hidden" name="clipboard_id" value="{{ clipboard.id }}" />


### PR DESCRIPTION
by adding a title attribute (which will show hover text).  Otherwise
users may think the clipboard is broken.