### PR TITLE
Remove unneccesary use of static()

### DIFF
--- a/filer/admin/imageadmin.py
+++ b/filer/admin/imageadmin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from django import forms
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.utils.translation import ugettext as _
 
 from filer.admin.fileadmin import FileAdmin
@@ -34,8 +33,8 @@ class ImageAdminForm(forms.ModelForm):
             # 'all': (settings.MEDIA_URL + 'filer/css/focal_point.css',)
         }
         js = (
-            static('filer/js/raphael.js'),
-            static('filer/js/focal_point.js'),
+            'filer/js/raphael.js',
+            'filer/js/focal_point.js',
         )
 
 

--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -5,7 +5,6 @@ import warnings
 from django import forms
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
 from django.contrib.admin.sites import site
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.template.loader import render_to_string
@@ -82,8 +81,8 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
 
     class Media:
         js = (
-            static('filer/js/popup_handling.js'),
-            static('filer/js/widget.js'),
+            'filer/js/popup_handling.js',
+            'filer/js/widget.js',
         )
 
 

--- a/filer/fields/folder.py
+++ b/filer/fields/folder.py
@@ -5,7 +5,6 @@ import warnings
 from django import forms
 from django.contrib.admin.sites import site
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.template.loader import render_to_string
@@ -79,7 +78,7 @@ class AdminFolderWidget(ForeignKeyRawIdWidget):
         return obj
 
     class Media:
-        js = (static('filer/js/popup_handling.js'), )
+        js = ('filer/js/popup_handling.js', )
 
 
 class AdminFolderFormField(forms.ModelChoiceField):


### PR DESCRIPTION
This fixes #630 (`collectstatic` broken with `ManifestStaticFilesStorage`).

As discussed there, these calls to `static()` were not required.

In case you want this against `develop`, please see here: https://github.com/djangsters/django-filer/tree/feature/fix-static