### PR TITLE
Pin django-polymorphic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'Django>=1.5',
         'easy-thumbnails>=1.0',
         'django-mptt>=0.6',
-        'django_polymorphic>=0.7',
+        'django_polymorphic>=0.7,<0.8',
         'Unidecode>=0.04',
     ),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,14 @@ deps=
     easy-thumbnails>2.0
     django15: django<1.6
     django15: south
+    django15: django-mptt>=0.6,<0.8
     django16: django<1.7
     django16: south
+    django16: django-mptt>=0.6,<0.8
     django17: django<1.8
+    django17: django-mptt>=0.6,<0.8
     django18: django<1.9
+    django18: django-mptt>=0.8,<0.9
     djangodev: git+git://github.com/django/django.git#egg=Django
     py26: unittest2
     py26: argparse


### PR DESCRIPTION
Pin django-polymorphic version to be below 0.8.

Also pins django-mptt in tox.

Note: Travis build is currently broken only because of django-mptt version being dependent on Django version. We'd better merge this quickly and do a version bump/release to fix issue for all the possible users.

The next steps: 

 * fix travis setup based on #643 
 * really support new django-polymorphic (broken because of imports and queryset methods proxying)