### PR TITLE
Improve tox/travis setup for front-end tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: python
 sudo: true
 
 before_install:
-  - if [[ $FRONTEND == "true" ]]; then npm install; fi;
-  - if [[ $FRONTEND == "true" ]]; then sudo apt-get update; fi;
-  - if [[ $FRONTEND == "true" ]]; then sudo apt-get install nodejs npm; fi;
+  - if [[ $TOX_ENV == "frontend" ]]; then sudo apt-get update && sudo apt-get install nodejs npm; fi;
 
 install:
   - pip install tox coveralls
@@ -47,10 +45,10 @@ env:
 #  - TOX_ENV=py34-django_master-thumbs2x
 #  - TOX_ENV=py33-django_master-thumbs2x
 #  - TOX_ENV=py27-django_master-thumbs2x
-  - FRONTEND=true
+  - TOX_ENV=frontend
 
 script:
-  - if [[ $FRONTEND = "true" ]]; then gulp ci; else tox -e $TOX_ENV; fi;
+  - tox -e $TOX_ENV
 
 after_success:
   - coveralls --config_file=coverage.rc

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
-envlist=
+envlist =
     flake8
     py{34,33,27}-django{19,18,17}-thumbs2x
     py{34,33,27}-django{18,17,16}-custom_image-thumbs2x
     py{34,33,27,26}-django{16,15}-thumbs1x
     py{34,33,27}-django_master-thumbs2x
+    frontend
 
 [testenv:docs]
-changedir=docs
+changedir = docs
 deps =
     sphinx
 commands =
@@ -21,6 +22,14 @@ commands = flake8
 ignore = E251,E128,E501
 exclude = build/*,docs/*,filer/migrations/*,filer/south_migrations/*,filer/migrations_django/*,filer/settings.py,filer/tests/*,filer/test_utils/custom_image/*,filer/test_utils/test_app/south_migrations/*
 max-line-length = 80
+
+[testenv:frontend]
+whitelist_externals =
+    npm
+    gulp
+commands =
+    - npm install
+    gulp ci
 
 [testenv]
 commands =


### PR DESCRIPTION
Improve tox/travis setup for front-end tests to make running front-end test suite locally easier.

 * Move gulp commands from travis to tox, simplify travis setup
 * Reorder `apt-get` and `npm` commands

This is a PR against the `develop` branch, as we have all front-end related improvements there.