### PR TITLE
folder admin: add missing search results querysets to context

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -399,6 +399,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             'search_string': ' '.join(search_terms),
             'q': urlquote(q),
             'show_result_count': show_result_count,
+            'folder_children': folder_children,
+            'folder_files': folder_files,
             'limit_search_to_folder': limit_search_to_folder,
             'is_popup': popup_status(request),
             'select_folder': selectfolder_status(request),


### PR DESCRIPTION
search_form.html template makes use of these variables, but they were
not set in the context.