### PR TITLE
Convert FILER_ADMIN_ICON_SIZES elements to strings

### DIFF
--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -135,7 +135,7 @@ class ClipboardAdmin(admin.ModelAdmin):
                 # Backwards compatibility: try to get specific icon size (32px)
                 # first. Then try medium icon size (they are already sorted),
                 # fallback to the first (smallest) configured icon.
-                for size in ([32] +
+                for size in (['32'] +
                              filer_settings.FILER_ADMIN_ICON_SIZES[1::-1]):
                     try:
                         thumbnail = file_obj.icons[size]

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -30,13 +30,15 @@ FILER_IS_PUBLIC_DEFAULT = getattr(settings, 'FILER_IS_PUBLIC_DEFAULT', True)
 
 FILER_PAGINATE_BY = getattr(settings, 'FILER_PAGINATE_BY', 20)
 
-_ICON_SIZES = getattr(settings, 'FILER_ADMIN_ICON_SIZES', (16, 32, 48, 64))
+_ICON_SIZES = getattr(settings, 'FILER_ADMIN_ICON_SIZES', ('16', '32', '48', '64'))
 if not _ICON_SIZES:
     raise ImproperlyConfigured('Please, configure FILER_ADMIN_ICON_SIZES')
-FILER_ADMIN_ICON_SIZES = sorted([int(s) for s in _ICON_SIZES])
+# Reliably sort by integer value, but keep icon size as string.
+# (There is some code in the wild that depends on this being strings.)
+FILER_ADMIN_ICON_SIZES = [str(i) for i in sorted([int(s) for s in _ICON_SIZES])]
 
 # Filer admin templates have specific icon sizes hardcoded: 32 and 48.
-_ESSENTIAL_ICON_SIZES = (32, 48)
+_ESSENTIAL_ICON_SIZES = ('32', '48')
 if not all(x in FILER_ADMIN_ICON_SIZES for x in _ESSENTIAL_ICON_SIZES):
     logger.warn(
         "FILER_ADMIN_ICON_SIZES has not all of the essential icon sizes "


### PR DESCRIPTION
There is some code in the wild that depends on this being strings. Namely, django-cms plugin Filer.