### PR TITLE
Fix wrong icon path in admin file widget

### DIFF
--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -6,7 +6,7 @@
             <div class="dz-thumbnail"><img class="quiet" data-dz-thumbnail></div>
             <span data-dz-name class="dz-name"></span>
             <img class="filerClearer" src="{% static admin_icon_delete %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"
-                 data-dz-remove data-no-icon-file="{% static 'filer/icon/nofile_48x48.png' %}">
+                 data-dz-remove data-no-icon-file="{% static 'filer/icons/nofile_48x48.png' %}">
             <div class="dz-progress js-filer-dropzone-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
         </span>
     </div>


### PR DESCRIPTION
The path `filer/icon/nofile_48x48.png` doesn't exist, use the correct one.

This bug surfaced when using ManifestStaticFilesStorage in combination with djangocms-page-meta. Accessing a non existing file raised an exception, which broke the forms render method, therefore not rendering the form at all.