### PR TITLE
rename django filer to Filer in breadcrumbs

### DIFF
--- a/filer/apps.py
+++ b/filer/apps.py
@@ -7,4 +7,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class FilerConfig(AppConfig):
     name = 'filer'
-    verbose_name = _("django filer")
+    verbose_name = _("Filer")


### PR DESCRIPTION
**This pull request fixes the following issues**:

|BEFORE|AFTER|
|---|---|
|![2016-04-14_1620](https://cloud.githubusercontent.com/assets/2270884/14566602/7c0b0f94-0330-11e6-804a-4da54e5fe291.png)|![screen shot 2016-04-15 at 17 35 02](https://cloud.githubusercontent.com/assets/2270884/14566603/80620f16-0330-11e6-877c-957eaa6d5c18.png)|

