### PR TITLE
fix: south migration for subject_location fails

### DIFF
--- a/filer/south_migrations/0016_auto__chg_field_image_subject_location.py
+++ b/filer/south_migrations/0016_auto__chg_field_image_subject_location.py
@@ -11,7 +11,8 @@ class Migration(SchemaMigration):
 
         # we are about to turn subject_location to not nullable. So any
         # existing entries with Null need to be converted to empty strings.
-        orm.Image.objects.filter(subject_location__isnull=True).update(subject_location='')
+        if not db.dry_run:
+            orm.Image.objects.filter(subject_location__isnull=True).update(subject_location='')
         db.alter_column('filer_image', 'subject_location', self.gf('django.db.models.fields.CharField')(max_length=64))
 
     def backwards(self, orm):

--- a/filer/south_migrations/0016_auto__chg_field_image_subject_location.py
+++ b/filer/south_migrations/0016_auto__chg_field_image_subject_location.py
@@ -9,7 +9,9 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
 
-        # Changing field 'Image.subject_location'
+        # we are about to turn subject_location to not nullable. So any
+        # existing entries with Null need to be converted to empty strings.
+        orm.Image.objects.filter(subject_location__isnull=True).update(subject_location='')
         db.alter_column('filer_image', 'subject_location', self.gf('django.db.models.fields.CharField')(max_length=64))
 
     def backwards(self, orm):


### PR DESCRIPTION
If there is existing rows in the database with subject_location=Null the
migration failed (on postgres).
This sets all Null fields to an empty string to prevent the error.

For projects who have already run this migration:
- if they were using a db backend where this does not matter: it does not matter
- if they were running a db backend where it does matter (postgres) and they had no null entries: all is fine
-  if they were running a db backend where it does matter (postgres) and they had null entries: the migration failed and thus has not run yet

For all the above cases it is fine that we just altered an existing migration instead of creating a new one.

~~Does anyone know if the same error occurs with the new style migrations?~~ I can confirm that the new style migrations work out of the box on postgres without a manual migration to switch from ``Null`` to ``''``.