### PR TITLE
[WiP] Offloading thumbnail generation to celery

### DIFF
--- a/filer/models/imagemodels.py
+++ b/filer/models/imagemodels.py
@@ -7,8 +7,10 @@ from datetime import datetime
 
 from django.conf import settings
 from django.db import models
+from django.dispatch import receiver
 from django.utils.timezone import get_current_timezone, make_aware, now
 from django.utils.translation import ugettext_lazy as _
+from easy_thumbnails.signals import saved_file
 
 from .. import settings as filer_settings
 from ..utils.loader import load_object
@@ -54,3 +56,10 @@ else:
     # This is just an alias for the real model defined elsewhere
     # to let imports works transparently
     Image = load_object(filer_settings.FILER_IMAGE_MODEL)
+
+
+@receiver(saved_file)
+def generate_thumbnails_async(sender, fieldfile, **kwargs):
+    if filer_settings.FILER_USE_CELERY:
+        from filer.tasks import generate_thumbnails
+        generate_thumbnails.delay(model=sender, pk=fieldfile.instance.pk, field=fieldfile.field.name)

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -245,3 +245,4 @@ FILER_UPLOADER_CONNECTIONS = getattr(
 FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether the filer shall dump the files payload
 
 FILER_CANONICAL_URL = getattr(settings, 'FILER_CANONICAL_URL', 'canonical/')
+FILER_USE_CELERY = getattr(settings, 'FILER_USE_CELERY', False)

--- a/filer/tasks.py
+++ b/filer/tasks.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from celery.app import shared_task
+
+from easy_thumbnails.files import generate_all_aliases
+
+
+@shared_task
+def generate_thumbnails(model, pk, field):
+    from filer.utils.filer_easy_thumbnails import load_aliases
+    load_aliases()
+    instance = model._default_manager.get(pk=pk)
+    fieldfile = getattr(instance, field)
+    generate_all_aliases(fieldfile, include_global=True)

--- a/filer/utils/filer_easy_thumbnails.py
+++ b/filer/utils/filer_easy_thumbnails.py
@@ -102,3 +102,24 @@ class FilerThumbnailer(ThumbnailerNameMixin, Thumbnailer):
 
 class FilerActionThumbnailer(ActionThumbnailerMixin, Thumbnailer):
     pass
+
+
+def load_aliases():
+    """
+    Load ThumbnailOption as easy-thumbnails aliases
+    """
+    from easy_thumbnails.alias import aliases
+
+    def _load_aliases():
+        from filer.models import ThumbnailOption
+        thumbs = ThumbnailOption.objects.all()
+        for thumb in thumbs:
+            if not aliases.get(thumb.name):
+                aliases.set(thumb.name, thumb.as_dict)
+
+    try:
+        if not aliases.filer_loaded:
+            _load_aliases()
+    except AttributeError:
+        _load_aliases()
+    aliases.filer_loaded = True


### PR DESCRIPTION
This is the initial commit that allows generating thumbnails using celery for all the registered ThumbnailOption sizes
This relies on easy-thumbnails celery / aliases support
More commits will follow to improve aliases support, tests and docs