### PR TITLE
Take hash into account when reloading

### DIFF
--- a/filer/static/filer/js/addons/upload-button.js
+++ b/filer/static/filer/js/addons/upload-button.js
@@ -33,10 +33,12 @@
         var updateQuery = function (uri, key, value) {
             var re = new RegExp('([?&])' + key + '=.*?(&|$)', 'i');
             var separator = uri.indexOf('?') !== -1 ? '&' : '?';
+            var hash = window.location.hash;
+            uri = uri.replace(/#.*$/, '');
             if (uri.match(re)) {
-                return uri.replace(re, '$1' + key + '=' + value + '$2');
+                return uri.replace(re, '$1' + key + '=' + value + '$2') + hash;
             } else {
-                return uri + separator + key + '=' + value;
+                return uri + separator + key + '=' + value + hash;
             }
         };
         var reloadOrdered = function () {


### PR DESCRIPTION
On reload the query parameters were added after the hash. This PR fixes this bug by cutting the hash and putting it back after computing the new uri.