### PR TITLE
Change on_delete behaviour

### DIFF
--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -104,7 +104,7 @@ class Folder(models.Model, mixins.IconsMixin):
     name = models.CharField(_('name'), max_length=255)
 
     owner = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), verbose_name=('owner'),
-                              related_name='filer_owned_folders',
+                              related_name='filer_owned_folders', on_delete=models.SET_NULL,
                               null=True, blank=True)
 
     uploaded_at = models.DateTimeField(_('uploaded at'), auto_now_add=True)
@@ -266,7 +266,7 @@ class FolderPermission(models.Model):
 
     type = models.SmallIntegerField(_('type'), choices=TYPES, default=ALL)
     user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
-                             related_name="filer_folder_permissions",
+                             related_name="filer_folder_permissions", on_delete=models.SET_NULL,
                              verbose_name=_("user"), blank=True, null=True)
     group = models.ForeignKey(auth_models.Group,
                               related_name="filer_folder_permissions",


### PR DESCRIPTION
Djangos default behaviour is to cascade the deletion of a user, which results in the deletion of files and folders.

Also on_delete will become a required argument in Django 2.0.