### PR TITLE
Removed all usages of `django.conf.urls.patterns`

### DIFF
--- a/docs/secure_downloads.rst
+++ b/docs/secure_downloads.rst
@@ -23,9 +23,9 @@ that would bypass the permission checks.
 To hook up the view ``filer.server.urls`` needs to be included in the root
 ``urls.py``::
 
-    urlpatterns += patterns('',
+    urlpatterns += [
         url(r'^', include('filer.server.urls')),
-    )
+    ]
 
 Files with restricted permissions need to be placed in a secure storage backend.
 Configure a secure storage backend in :ref:`FILER_STORAGES` or use the default.

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -39,9 +39,8 @@ class ClipboardAdmin(admin.ModelAdmin):
     verbose_name_plural = "DEBUG Clipboards"
 
     def get_urls(self):
-        from django.conf.urls import patterns, url
-        urls = super(ClipboardAdmin, self).get_urls()
-        url_patterns = patterns('',
+        from django.conf.urls import url
+        url_patterns = [
             url(r'^operations/paste_clipboard_to_folder/$',
                 self.admin_site.admin_view(views.paste_clipboard_to_folder),
                 name='filer-paste_clipboard_to_folder'),
@@ -57,8 +56,8 @@ class ClipboardAdmin(admin.ModelAdmin):
             url(r'^operations/upload/no_folder/$',
                 ajax_upload,
                 name='filer-ajax_upload'),
-        )
-        url_patterns.extend(urls)
+        ]
+        url_patterns.extend(super(ClipboardAdmin, self).get_urls())
         return url_patterns
 
     def get_model_perms(self, *args, **kwargs):

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -214,9 +214,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
     icon_img.allow_tags = True
 
     def get_urls(self):
-        from django.conf.urls import patterns, url
-        urls = super(FolderAdmin, self).get_urls()
-        url_patterns = patterns('',
+        from django.conf.urls import url
+        url_patterns = [
             # we override the default list view with our own directory listing
             # of the root directories
             url(r'^$',
@@ -248,8 +247,10 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                 self.admin_site.admin_view(self.directory_listing),
                 {'viewtype': 'unfiled_images'},
                 name='filer-directory_listing-unfiled_images'),
+        ]
+        url_patterns.extend(
+            super(FolderAdmin, self).get_urls()
         )
-        url_patterns.extend(urls)
         return url_patterns
 
     # custom views

--- a/filer/server/main_server_urls.py
+++ b/filer/server/main_server_urls.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('filer.server.views',
-    url(r'^(?P<path>.*)$', 'serve_protected_file', ),
-)
+urlpatterns = [
+    url(r'^(?P<path>.*)$', 'filer.server.views.serve_protected_file', ),
+]

--- a/filer/server/thumbnails_server_urls.py
+++ b/filer/server/thumbnails_server_urls.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('filer.server.views',
-    url(r'^(?P<path>.*)$', 'serve_protected_thumbnail',),
-)
+urlpatterns = [
+    url(r'^(?P<path>.*)$', 'filer.server.views.serve_protected_thumbnail',),
+]

--- a/filer/server/urls.py
+++ b/filer/server/urls.py
@@ -2,14 +2,14 @@
 
 from __future__ import absolute_import
 
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from .. import settings as filer_settings
 
 if not filer_settings.FILER_0_8_COMPATIBILITY_MODE:
-    urlpatterns = patterns('filer.server.views',
+    urlpatterns = [
         url(r'^' + filer_settings.FILER_PRIVATEMEDIA_STORAGE.base_url.lstrip('/'), include('filer.server.main_server_urls')),
         url(r'^' + filer_settings.FILER_PRIVATEMEDIA_THUMBNAIL_STORAGE.base_url.lstrip('/'), include('filer.server.thumbnails_server_urls')),
-    )
+    ]
 else:
-    urlpatterns = patterns('')
+    urlpatterns = []

--- a/filer/test_utils/urls.py
+++ b/filer/test_utils/urls.py
@@ -3,15 +3,15 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^media/(?P<path>.*)$', 'django.views.static.serve',  # NOQA
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^', include('filer.server.urls')),
     url(r'^filer/', include('filer.urls')),
-)
+]


### PR DESCRIPTION
This is a clean PR which can replace #721.