### PR TITLE
Add missing migration

### DIFF
--- a/filer/migrations/0005_auto_20160429_1025.py
+++ b/filer/migrations/0005_auto_20160429_1025.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+
+    dependencies = [
+        ('filer', '0004_auto_20160328_1434'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='image',
+            name='subject_location',
+            field=models.CharField(blank=True, default='', max_length=64, verbose_name='subject location'),
+        ),
+    ]


### PR DESCRIPTION
This migration was left out of the latest version. It is being ignored by Django 1.8/1.9 and cms-helper (which is probably how it happened), but it brings the DB to the correct state (change of a default value to subject_location) and tests work in both cases.