### PR TITLE
Make Image model swappable using a Meta.swappable option

### DIFF
--- a/docs/extending_filer.rst
+++ b/docs/extending_filer.rst
@@ -38,7 +38,7 @@ In your own application, you need to create a Video model. This model has to inh
         pass # for now...
     
 
-When a file is uploaded, :py:meth:`filer.admin.clipboardadmin.ClipboardAdmin.ajax_upload` loops over the different classes in ``filer.settings.FILER_FILE_MODELS`` and calls its ``matches_file_type()`` to see if the file matches a known filename extension.
+When a file is uploaded, :py:meth:`filer.admin.clipboardadmin.ClipboardAdmin.ajax_upload` loops over the different models in ``filer.settings.FILER_FILE_MODELS`` and calls its ``matches_file_type()`` to see if the file matches a known filename extension.
 
 When a match is found, the filer will create an instance of that class for the file.
 

--- a/filer/admin/__init__.py
+++ b/filer/admin/__init__.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib import admin
+
+from ..models import Clipboard, File, Folder, FolderPermission, ThumbnailOption
+from ..settings import FILER_IMAGE_MODEL
+from ..utils.loader import load_model
 from .clipboardadmin import ClipboardAdmin
 from .fileadmin import FileAdmin
 from .folderadmin import FolderAdmin
 from .imageadmin import ImageAdmin
-from .thumbnailoptionadmin import ThumbnailOptionAdmin
 from .permissionadmin import PermissionAdmin
-from ..models import FolderPermission, Folder, File, Clipboard, Image, ThumbnailOption
+from .thumbnailoptionadmin import ThumbnailOptionAdmin
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 admin.site.register(Folder, FolderAdmin)

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -18,7 +18,7 @@ from ..utils.files import (
     handle_request_files_upload,
     handle_upload,
 )
-from ..utils.loader import load_object
+from ..utils.loader import load_model
 
 NO_FOLDER_ERROR = "Can't find folder to upload. Please refresh and try again"
 NO_PERMISSIONS_FOR_FOLDER = (
@@ -104,7 +104,7 @@ def ajax_upload(request, folder_id=None):
 
         # find the file type
         for filer_class in filer_settings.FILER_FILE_MODELS:
-            FileSubClass = load_object(filer_class)
+            FileSubClass = load_model(filer_class)
             # TODO: What if there are more than one that qualify?
             if FileSubClass.matches_file_type(filename, upload, request):
                 FileForm = modelform_factory(

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -31,12 +31,11 @@ from ..models import (
     Folder,
     FolderPermission,
     FolderRoot,
-    Image,
     ImagesWithMissingData,
     UnsortedImages,
     tools,
 )
-from ..settings import FILER_PAGINATE_BY
+from ..settings import FILER_IMAGE_MODEL, FILER_PAGINATE_BY
 from ..thumbnail_processors import normalize_subject_location
 from ..utils.compatibility import (
     capfirst,
@@ -45,6 +44,7 @@ from ..utils.compatibility import (
     unquote,
 )
 from ..utils.filer_easy_thumbnails import FilerActionThumbnailer
+from ..utils.loader import load_model
 from .forms import CopyFilesAndFoldersForm, RenameFilesForm, ResizeImagesForm
 from .patched.admin_utils import get_deleted_objects
 from .permissions import PrimitivePermissionAwareModelAdmin
@@ -59,6 +59,8 @@ from .tools import (
     popup_status,
     userperms_for_request,
 )
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 class AddFolderPopupForm(forms.ModelForm):

--- a/filer/admin/imageadmin.py
+++ b/filer/admin/imageadmin.py
@@ -5,9 +5,12 @@ from django import forms
 from django.utils.translation import ugettext as _
 from django.utils.translation import string_concat, ugettext_lazy
 
-from ..models import Image
+from ..settings import FILER_IMAGE_MODEL
 from ..thumbnail_processors import normalize_subject_location
+from ..utils.loader import load_model
 from .fileadmin import FileAdmin
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 class ImageAdminForm(forms.ModelForm):

--- a/filer/fields/image.py
+++ b/filer/fields/image.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from ..models import Image
+from .. import settings
+from ..utils.loader import load_model
 from .file import AdminFileFormField, AdminFileWidget, FilerFileField
 
 
@@ -15,4 +16,4 @@ class AdminImageFormField(AdminFileFormField):
 
 class FilerImageField(FilerFileField):
     default_form_class = AdminImageFormField
-    default_model_class = Image
+    default_model_class = load_model(settings.FILER_IMAGE_MODEL)

--- a/filer/fields/image.py
+++ b/filer/fields/image.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 
 from .. import settings
-from ..utils.loader import load_model
 from .file import AdminFileFormField, AdminFileWidget, FilerFileField
 
 
@@ -16,4 +15,4 @@ class AdminImageFormField(AdminFileFormField):
 
 class FilerImageField(FilerFileField):
     default_form_class = AdminImageFormField
-    default_model_class = load_model(settings.FILER_IMAGE_MODEL)
+    default_model_class = settings.FILER_IMAGE_MODEL

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -9,9 +9,11 @@ from django.core.management.base import BaseCommand, NoArgsCommand
 
 from ...models.filemodels import File
 from ...models.foldermodels import Folder
-from ...models.imagemodels import Image
-from ...settings import FILER_IS_PUBLIC_DEFAULT
+from ...settings import FILER_IMAGE_MODEL, FILER_IS_PUBLIC_DEFAULT
 from ...utils.compatibility import upath
+from ...utils.loader import load_model
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 class FileImporter(object):

--- a/filer/migrations/0001_initial.py
+++ b/filer/migrations/0001_initial.py
@@ -143,27 +143,25 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(related_name='filer_clipboards', verbose_name='user', to=settings.AUTH_USER_MODEL),
             preserve_default=True,
         ),
-    ]
-    if not FILER_IMAGE_MODEL:
-        operations.append(
-            migrations.CreateModel(
-                name='Image',
-                fields=[
-                    ('file_ptr', models.OneToOneField(serialize=False, auto_created=True, to='filer.File', primary_key=True, parent_link=True)),
-                    ('_height', models.IntegerField(null=True, blank=True)),
-                    ('_width', models.IntegerField(null=True, blank=True)),
-                    ('date_taken', models.DateTimeField(verbose_name='date taken', null=True, editable=False, blank=True)),
-                    ('default_alt_text', models.CharField(max_length=255, null=True, verbose_name='default alt text', blank=True)),
-                    ('default_caption', models.CharField(max_length=255, null=True, verbose_name='default caption', blank=True)),
-                    ('author', models.CharField(max_length=255, null=True, verbose_name='author', blank=True)),
-                    ('must_always_publish_author_credit', models.BooleanField(default=False, verbose_name='must always publish author credit')),
-                    ('must_always_publish_copyright', models.BooleanField(default=False, verbose_name='must always publish copyright')),
-                    ('subject_location', models.CharField(default=None, max_length=64, null=True, verbose_name='subject location', blank=True)),
-                ],
-                options={
-                    'verbose_name': 'image',
-                    'verbose_name_plural': 'images',
-                },
-                bases=('filer.file',),
-            )
+        migrations.CreateModel(
+            name='Image',
+            fields=[
+                ('file_ptr', models.OneToOneField(serialize=False, auto_created=True, to='filer.File', primary_key=True, parent_link=True)),
+                ('_height', models.IntegerField(null=True, blank=True)),
+                ('_width', models.IntegerField(null=True, blank=True)),
+                ('date_taken', models.DateTimeField(verbose_name='date taken', null=True, editable=False, blank=True)),
+                ('default_alt_text', models.CharField(max_length=255, null=True, verbose_name='default alt text', blank=True)),
+                ('default_caption', models.CharField(max_length=255, null=True, verbose_name='default caption', blank=True)),
+                ('author', models.CharField(max_length=255, null=True, verbose_name='author', blank=True)),
+                ('must_always_publish_author_credit', models.BooleanField(default=False, verbose_name='must always publish author credit')),
+                ('must_always_publish_copyright', models.BooleanField(default=False, verbose_name='must always publish copyright')),
+                ('subject_location', models.CharField(default=None, max_length=64, null=True, verbose_name='subject location', blank=True)),
+            ],
+            options={
+                'swappable': 'FILER_IMAGE_MODEL',
+                'verbose_name': 'image',
+                'verbose_name_plural': 'images',
+            },
+            bases=('filer.file',),
         )
+    ]

--- a/filer/migrations/0004_auto_20160328_1434.py
+++ b/filer/migrations/0004_auto_20160328_1434.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
-from filer.settings import FILER_IMAGE_MODEL
-
 
 class Migration(migrations.Migration):
 
@@ -13,12 +11,10 @@ class Migration(migrations.Migration):
         ('filer', '0003_thumbnailoption'),
     ]
 
-    if not FILER_IMAGE_MODEL:
-        # Only attempt to alter the Image field if we're actually using it.
-        operations = [
-            migrations.AlterField(
-                model_name='image',
-                name='subject_location',
-                field=models.CharField(blank=True, default='', max_length=64, verbose_name='subject location'),
-            ),
-        ]
+    operations = [
+        migrations.AlterField(
+            model_name='image',
+            name='subject_location',
+            field=models.CharField(blank=True, default='', max_length=64, verbose_name='subject location'),
+        ),
+    ]

--- a/filer/migrations/0006_auto_20160623_1627.py
+++ b/filer/migrations/0006_auto_20160623_1627.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 
-from filer.settings import FILER_IMAGE_MODEL
-
 
 class Migration(migrations.Migration):
 
@@ -14,11 +12,10 @@ class Migration(migrations.Migration):
         ('filer', '0005_auto_20160623_1425'),
     ]
 
-    if not FILER_IMAGE_MODEL:
-        operations = [
-            migrations.AlterField(
-                model_name='image',
-                name='file_ptr',
-                field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, related_name='%(app_label)s_%(class)s_file', serialize=False, to='filer.File'),
-            ),
-        ]
+    operations = [
+        migrations.AlterField(
+            model_name='image',
+            name='file_ptr',
+            field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, related_name='%(app_label)s_%(class)s_file', serialize=False, to='filer.File'),
+        ),
+    ]

--- a/filer/models/imagemodels.py
+++ b/filer/models/imagemodels.py
@@ -10,54 +10,42 @@ from django.db import models
 from django.utils.timezone import get_current_timezone, make_aware, now
 from django.utils.translation import ugettext_lazy as _
 
-from .. import settings as filer_settings
 from ..utils.compatibility import GTE_DJANGO_1_10
-from ..utils.loader import load_object
 from .abstract import BaseImage
 
 logger = logging.getLogger("filer")
 
 
-if not filer_settings.FILER_IMAGE_MODEL:
-    # This is the standard Image model
-    class Image(BaseImage):
-        date_taken = models.DateTimeField(_('date taken'), null=True, blank=True,
-                                          editable=False)
-        author = models.CharField(_('author'), max_length=255, null=True, blank=True)
-        must_always_publish_author_credit = models.BooleanField(_('must always publish author credit'), default=False)
-        must_always_publish_copyright = models.BooleanField(_('must always publish copyright'), default=False)
+# This is the standard Image model which can be swapped for a custom model using FILER_IMAGE_MODEL setting
+class Image(BaseImage):
+    date_taken = models.DateTimeField(_('date taken'), null=True, blank=True,
+                                      editable=False)
+    author = models.CharField(_('author'), max_length=255, null=True, blank=True)
+    must_always_publish_author_credit = models.BooleanField(_('must always publish author credit'), default=False)
+    must_always_publish_copyright = models.BooleanField(_('must always publish copyright'), default=False)
 
-        class Meta(object):
-            app_label = 'filer'
-            verbose_name = _('image')
-            verbose_name_plural = _('images')
-            if GTE_DJANGO_1_10:
-                default_manager_name = 'objects'
+    class Meta(BaseImage.Meta):
+        swappable = 'FILER_IMAGE_MODEL'
 
-        def save(self, *args, **kwargs):
-            if self.date_taken is None:
-                try:
-                    exif_date = self.exif.get('DateTimeOriginal', None)
-                    if exif_date is not None:
-                        d, t = exif_date.split(" ")
-                        year, month, day = d.split(':')
-                        hour, minute, second = t.split(':')
-                        if getattr(settings, "USE_TZ", False):
-                            tz = get_current_timezone()
-                            self.date_taken = make_aware(datetime(
-                                int(year), int(month), int(day),
-                                int(hour), int(minute), int(second)), tz)
-                        else:
-                            self.date_taken = datetime(
-                                int(year), int(month), int(day),
-                                int(hour), int(minute), int(second))
-                except Exception:
-                    pass
-            if self.date_taken is None:
-                self.date_taken = now()
-            super(Image, self).save(*args, **kwargs)
-
-else:
-    # This is just an alias for the real model defined elsewhere
-    # to let imports works transparently
-    Image = load_object(filer_settings.FILER_IMAGE_MODEL)
+    def save(self, *args, **kwargs):
+        if self.date_taken is None:
+            try:
+                exif_date = self.exif.get('DateTimeOriginal', None)
+                if exif_date is not None:
+                    d, t = exif_date.split(" ")
+                    year, month, day = d.split(':')
+                    hour, minute, second = t.split(':')
+                    if getattr(settings, "USE_TZ", False):
+                        tz = get_current_timezone()
+                        self.date_taken = make_aware(datetime(
+                            int(year), int(month), int(day),
+                            int(hour), int(minute), int(second)), tz)
+                    else:
+                        self.date_taken = datetime(
+                            int(year), int(month), int(day),
+                            int(hour), int(minute), int(second))
+            except Exception:
+                pass
+        if self.date_taken is None:
+            self.date_taken = now()
+        super(Image, self).save(*args, **kwargs)

--- a/filer/models/imagemodels.py
+++ b/filer/models/imagemodels.py
@@ -26,6 +26,8 @@ class Image(BaseImage):
 
     class Meta(BaseImage.Meta):
         swappable = 'FILER_IMAGE_MODEL'
+        if GTE_DJANGO_1_10:
+            default_manager_name = 'objects'
 
     def save(self, *args, **kwargs):
         if self.date_taken is None:

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -54,8 +54,7 @@ if not all(x in FILER_ADMIN_ICON_SIZES for x in _ESSENTIAL_ICON_SIZES):
 # classes that I should check for when adding files
 FILER_FILE_MODELS = getattr(
     settings, 'FILER_FILE_MODELS',
-    # FIXME: the default is broken ATM because FILER_IMAGE_MODEL is a content type (not full python path)
-    (FILER_IMAGE_MODEL, 'filer.models.filemodels.File'))
+    (FILER_IMAGE_MODEL, 'filer.File'))
 
 DEFAULT_FILE_STORAGE = getattr(settings, 'DEFAULT_FILE_STORAGE', 'django.core.files.storage.FileSystemStorage')
 

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -13,7 +13,9 @@ from .utils.recursive_dictionary import RecursiveDictionaryWithExcludes
 
 logger = logging.getLogger(__name__)
 
-FILER_IMAGE_MODEL = getattr(settings, 'FILER_IMAGE_MODEL', False)
+# This represents the actual Image model (as opposed to FILER_IMAGE_MODEL global setting which could be
+# undefined)
+FILER_IMAGE_MODEL = getattr(settings, 'FILER_IMAGE_MODEL', 'filer.Image')
 FILER_DEBUG = getattr(settings, 'FILER_DEBUG', False)  # When True makes
 FILER_SUBJECT_LOCATION_IMAGE_DEBUG = getattr(settings, 'FILER_SUBJECT_LOCATION_IMAGE_DEBUG', False)
 FILER_WHITESPACE_COLOR = getattr(settings, 'FILER_WHITESPACE_COLOR', '#FFFFFF')
@@ -52,8 +54,8 @@ if not all(x in FILER_ADMIN_ICON_SIZES for x in _ESSENTIAL_ICON_SIZES):
 # classes that I should check for when adding files
 FILER_FILE_MODELS = getattr(
     settings, 'FILER_FILE_MODELS',
-    (FILER_IMAGE_MODEL if FILER_IMAGE_MODEL else 'filer.models.imagemodels.Image',
-     'filer.models.filemodels.File'))
+    # FIXME: the default is broken ATM because FILER_IMAGE_MODEL is a content type (not full python path)
+    (FILER_IMAGE_MODEL, 'filer.models.filemodels.File'))
 
 DEFAULT_FILE_STORAGE = getattr(settings, 'DEFAULT_FILE_STORAGE', 'django.core.files.storage.FileSystemStorage')
 

--- a/filer/test_utils/test_app/migrations/0001_initial.py
+++ b/filer/test_utils/test_app/migrations/0001_initial.py
@@ -10,7 +10,7 @@ import filer.fields.image
 
 class Migration(migrations.Migration):
 
-    if FILER_IMAGE_MODEL:
+    if FILER_IMAGE_MODEL.startswith('custom_image'):
         dependencies = [
             ('filer', '0001_initial'),
             ('custom_image', '0001_initial'),
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('folder', filer.fields.folder.FilerFolderField(related_name='test_folder', to='filer.Folder')),
                 ('general', filer.fields.file.FilerFileField(related_name='test_file', to='filer.File')),
-                ('image', filer.fields.image.FilerImageField(related_name='test_image', to=FILER_IMAGE_MODEL or 'filer.Image')),
+                ('image', filer.fields.image.FilerImageField(related_name='test_image', to=FILER_IMAGE_MODEL)),
             ],
             options={
             },

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -31,8 +31,6 @@ from ..utils.loader import load_model
 
 Image = load_model(FILER_IMAGE_MODEL)
 
-from filer.settings import FILER_IMAGE_MODEL
-
 try:
     from unittest import skipIf
 except ImportError:  # for python 2.6

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -206,10 +206,10 @@ class FilerClipboardAdminUrlsTests(TestCase):
 
     def test_filer_upload_video(self, extra_headers={}):
         with SettingsOverride(filer_settings, FILER_FILE_MODELS=(
-            'filer.test_utils.extended_app.models.ExtImage',
-            'filer.test_utils.extended_app.models.Video',
-            'filer.models.imagemodels.Image',
-            'filer.models.filemodels.File'
+            'extended_app.ExtImage',
+            'extended_app.Video',
+            'filer.Image',
+            'filer.File'
         )):
             self.assertEqual(Video.objects.count(), 0)
             folder = Folder.objects.create(name='foo')
@@ -226,10 +226,10 @@ class FilerClipboardAdminUrlsTests(TestCase):
 
     def test_filer_upload_extimage(self, extra_headers={}):
         with SettingsOverride(filer_settings, FILER_FILE_MODELS=(
-            'filer.test_utils.extended_app.models.ExtImage',
-            'filer.test_utils.extended_app.models.Video',
-            'filer.models.imagemodels.Image',
-            'filer.models.filemodels.File'
+            'extended_app.ExtImage',
+            'extended_app.Video',
+            'filer.Image',
+            'filer.File'
         )):
             self.assertEqual(ExtImage.objects.count(), 0)
             folder = Folder.objects.create(name='foo')

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -18,8 +18,8 @@ from .. import settings as filer_settings
 from ..admin.folderadmin import FolderAdmin
 from ..models.filemodels import File
 from ..models.foldermodels import Folder, FolderPermission
-from ..models.imagemodels import Image
 from ..models.virtualitems import FolderRoot
+from ..settings import FILER_IMAGE_MODEL
 from ..tests.helpers import (
     SettingsOverride,
     create_folder_structure,
@@ -27,6 +27,9 @@ from ..tests.helpers import (
     create_superuser,
 )
 from ..thumbnail_processors import normalize_subject_location
+from ..utils.loader import load_model
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 from filer.settings import FILER_IMAGE_MODEL
 

--- a/filer/tests/dump.py
+++ b/filer/tests/dump.py
@@ -14,13 +14,16 @@ from django.utils.six import StringIO
 from .. import settings as filer_settings
 from ..models import Folder
 from ..models.filemodels import File
-from ..models.imagemodels import Image
+from ..settings import FILER_IMAGE_MODEL
 from ..tests.helpers import (
     SettingsOverride,
     create_folder_structure,
     create_image,
     create_superuser,
 )
+from ..utils.loader import load_model
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 class DumpDataTests(TestCase):

--- a/filer/tests/models.py
+++ b/filer/tests/models.py
@@ -252,7 +252,7 @@ class FilerApiTests(TestCase):
         Check that the correct model is loaded and save / reload data
         """
         image = self.create_filer_image()
-        if settings.FILER_IMAGE_MODEL:
+        if getattr(settings, 'FILER_IMAGE_MODEL', False):
             self.assertTrue(hasattr(image, 'extra_description'))
             self.assertFalse(hasattr(image, 'author'))
             image.extra_description = 'Extra'

--- a/filer/tests/models.py
+++ b/filer/tests/models.py
@@ -12,15 +12,18 @@ from .. import settings as filer_settings
 from ..models.clipboardmodels import Clipboard
 from ..models.filemodels import File
 from ..models.foldermodels import Folder
-from ..models.imagemodels import Image
 from ..models.mixins import IconsMixin
+from ..settings import FILER_IMAGE_MODEL
 from ..test_utils import ET_2
+from ..utils.loader import load_model
 from .helpers import (
     create_clipboard_item,
     create_folder_structure,
     create_image,
     create_superuser,
 )
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 try:
     from unittest import skipIf, skipUnless

--- a/filer/tests/permissions.py
+++ b/filer/tests/permissions.py
@@ -11,9 +11,12 @@ from django.test.testcases import TestCase
 from .. import settings as filer_settings
 from ..models.clipboardmodels import Clipboard
 from ..models.foldermodels import Folder, FolderPermission
-from ..models.imagemodels import Image
+from ..settings import FILER_IMAGE_MODEL
+from ..utils.loader import load_model
 from .helpers import create_image, create_superuser
 from .utils import Mock
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 class FolderPermissionsTestCase(TestCase):

--- a/filer/tests/tools.py
+++ b/filer/tests/tools.py
@@ -10,8 +10,11 @@ from django.test.testcases import TestCase
 from ..models import tools
 from ..models.clipboardmodels import Clipboard
 from ..models.foldermodels import Folder
-from ..models.imagemodels import Image
+from ..settings import FILER_IMAGE_MODEL
+from ..utils.loader import load_model
 from .helpers import create_image, create_superuser
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 class ToolsTestCase(TestCase):

--- a/filer/utils/loader.py
+++ b/filer/utils/loader.py
@@ -41,6 +41,18 @@ def load_object(import_path):
     return getattr(module, object_name)
 
 
+def load_model(model_name):
+    from django import VERSION as django_version
+
+    model_name_tuple = model_name.split('.')
+
+    if django_version[:2] < (1, 7):
+        from django.db.models import get_model
+        return get_model(*model_name_tuple)
+    from django.apps import apps
+    return apps.get_model(*model_name_tuple)
+
+
 def storage_factory(klass, location, base_url):
     """
     This factory returns an instance of the storage class provided.

--- a/test_settings.py
+++ b/test_settings.py
@@ -57,12 +57,11 @@ HELPER_SETTINGS = {
         'easy_thumbnails.processors.filters',
     ),
     'FILE_UPLOAD_TEMP_DIR': mkdtemp(),
-    'FILER_IMAGE_MODEL': False,
     'TEMPLATE_DIRS': (os.path.join(BASE_DIR, 'django-filer', 'filer', 'test_utils', 'templates'),),
     'FILER_CANONICAL_URL': 'test-path/',
 }
 if os.environ.get('CUSTOM_IMAGE', False):
-    HELPER_SETTINGS['FILER_IMAGE_MODEL'] = os.environ.get('CUSTOM_IMAGE', False)
+    HELPER_SETTINGS['FILER_IMAGE_MODEL'] = os.environ.get('CUSTOM_IMAGE')
     HELPER_SETTINGS['INSTALLED_APPS'].append('filer.test_utils.custom_image')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     coverage run test_settings.py {posargs}
     - coverage report
 setenv =
-    custom_image: CUSTOM_IMAGE=filer.test_utils.custom_image.models.Image
+    custom_image: CUSTOM_IMAGE=custom_image.Image
 deps =
     thumbs1x: easy-thumbnails>=1.4,<2.0
     thumbs2x: easy-thumbnails>=2.0,<2.4


### PR DESCRIPTION
Custom Image models are still problematic mostly because of issues with migrations. This is because Image model swappability implementation in filer is sort of broken by design :) I propose switching to a standard Django way for model swapping - Meta.swappable option.

The branch in it's current form is already working but I'm marking is as a Work in progress because there are some problems:
- FILER_IMAGE_MODEL setting now uses django content type instead of full python path to model. This breaks compatibility, however it's very easy to fix.
- FILER_FILE_MODELS setting default is currently broken for the same reason. I think it would be a good idea to switch FILER_FILE_MODELS setting to content type syntax as well but this is not for me to decide.
