### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,4 +28,4 @@ Filer picker widget:
 Please head over to `documentation`_ for all the details on how to install,
 configure and use django-filer.
 
-.. _documentation: http://django-filer.readthedocs.org/en/latest/index.html
+.. _documentation: https://django-filer.readthedocs.io/en/latest/index.html

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -174,7 +174,7 @@ generation errors,  two options are provided to help when working with ``django-
 .. _sorl.thumbnail: http://thumbnail.sorl.net/
 .. _django-mptt: https://github.com/django-mptt/django-mptt/
 .. _Pillow: http://pypi.python.org/pypi/Pillow/
-.. _Pillow doc: http://pillow.readthedocs.org/en/latest/installation.html
+.. _Pillow doc: https://pillow.readthedocs.io/en/latest/installation.html
 .. _PIL: http://www.pythonware.com/products/pil/
 .. _pip: http://pypi.python.org/pypi/pip
 .. _South: http://south.aeracode.org/

--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -8,7 +8,7 @@ django-filer is continuously being tested on `travis-ci <https://travis-ci.org/d
 
 There is no easy way to run test suite on any python version you have installed without using ``tox``.
 
-The recommended way to test locally is with `tox <http://tox.readthedocs.org/en/latest/>`_. Once ``tox`` is installed,
+The recommended way to test locally is with `tox <https://tox.readthedocs.io/en/latest/>`_. Once ``tox`` is installed,
 simply running the ``tox`` command inside the package root. You don't need to bother with any virtualenvs, it will be
 done for you. Tox will setup multiple virtual environments with different python and django versions to test against::
 
@@ -22,7 +22,7 @@ done for you. Tox will setup multiple virtual environments with different python
     tox -e py27-django18-thumbs2x -- test filer.tests.models.FilerApiTests.test_create_folder_structure
 
 Other test runner options are also supported, see
-`djangocms-helper <http://djangocms-helper.readthedocs.org/en/develop/>`_
+`djangocms-helper <https://djangocms-helper.readthedocs.io/en/develop/>`_
 documentation for details.
 
 To speed things up a bit use `detox <http://pypi.python.org/pypi/detox/>`_. ``detox`` runs each testsuite in a


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.