### PR TITLE
Admin: directory-listing permissions speedup

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -360,8 +360,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             folder_files.sort()
 
         items = folder_children + folder_files
-        items_permissions = [(item, {'change': self.has_change_permission(request, item)}) for item in items]
-        paginator = Paginator(items_permissions, FILER_PAGINATE_BY)
+        paginator = Paginator(items, FILER_PAGINATE_BY)
 
         # Are we moving to clipboard?
         if request.method == 'POST' and '_save' not in request.POST:

--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -36,7 +36,7 @@
                     </td>
                 </tr>
             {% endfor %}
-            {% for item, item_perms in paginated_items.object_list %}
+            {% for item in paginated_items.object_list %}
                 {% if item.file_type == "Folder" %}
                     {% with item as subfolder %}
                         <tr class="js-filer-dropzone js-filer-dropzone-folder" data-url="{% url 'admin:filer-ajax_upload' folder_id=subfolder.id %}" data-folder-name="{{ subfolder.name }}" data-max-uploader-connections="{{ uploader_connections }}" data-max-file-size="20">
@@ -85,6 +85,7 @@
                     {% endwith %}
                 {% else %}
                     {% with item as file %}
+                        {% filer_has_permission item 'edit' as has_change_permission %}
                         <tr>
                             <td class="column-checkbox">
                                 {% if is_popup and filer_admin_context.pick_file %}
@@ -98,12 +99,12 @@
                                 {% if is_popup and filer_admin_context.pick_file %}
                                     <a href="#" onclick="opener.dismissRelatedImageLookupPopup(window, {{ file.id|unlocalize }}, '{{ file.icons.48|escapejs }}', '{{ file.label|escapejs }}'); return false;"
                                         title="{% trans 'Select this file' %}">
-                                {% elif item_perms.change %}
+                                {% elif has_change_permission %}
                                     <a href="{{ file.get_admin_change_url }}{% filer_admin_context_url_params %}"
                                             title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">
                                 {% endif %}
                                     <img src="{% if file.icons.48 %}{{ file.icons.48 }}{% else %}{% static 'filer/icons/missingfile_48x48.png' %}{% endif %}" alt="{{ file.default_alt_text }}" width="28" height="28">
-                                {% if item_perms.change or is_popup and filer_admin_context.pick_file %}
+                                {% if has_change_permission or is_popup and filer_admin_context.pick_file %}
                                     </a>
                                 {% endif %}
                             </td>
@@ -113,12 +114,12 @@
                                         {% if is_popup and filer_admin_context.pick_file %}
                                             <a href="#" onclick="opener.dismissRelatedImageLookupPopup(window, {{ file.id|unlocalize }}, '{{ file.icons.48|escapejs }}', '{{ file.label|escapejs }}'); return false;"
                                                 title="{% trans 'Select this file' %}">
-                                        {% elif item_perms.change %}
+                                        {% elif has_change_permission %}
                                             <a href="{{ file.get_admin_change_url }}{% filer_admin_context_url_params %}"
                                                 title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">
                                         {% endif %}
                                         {{ file.label }}
-                                        {% if item_perms.change or is_popup and filer_admin_context.pick_file %}
+                                        {% if has_change_permission or is_popup and filer_admin_context.pick_file %}
                                             </a>
                                         {% endif %}
                                     </strong>

--- a/filer/templatetags/filer_admin_tags.py
+++ b/filer/templatetags/filer_admin_tags.py
@@ -34,3 +34,20 @@ def filer_admin_context_hidden_formfields(context):
         '<input type="hidden" name="{0}" value="{1}">',
         admin_url_params(request).items(),
     )
+
+
+@register.assignment_tag(takes_context=True)
+def filer_has_permission(context, item, action):
+    """Does the current user (taken from the request in the context) have
+    permission to do the given action on the given item.
+
+    """
+    permission_method_name = 'has_{action}_permission'.format(action=action)
+    permission_method = getattr(item, permission_method_name, None)
+    request = context.get('request')
+
+    if not permission_method or not request:
+        return False
+    # Call the permission method.
+    # This amounts to calling `item.has_X_permission(request)`
+    return permission_method(request)

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -805,7 +805,7 @@ class FolderListingTest(TestCase):
             item_list = response.context['paginated_items'].object_list
             # user sees all items: FOO, BAR, BAZ, SAMP
             self.assertEquals(
-                set(folder.pk for folder, folder_perms in item_list),
+                set(folder.pk for folder in item_list),
                 set([self.foo_folder.pk, self.bar_folder.pk, self.baz_folder.pk,
                      self.spam_file.pk]))
 
@@ -819,7 +819,7 @@ class FolderListingTest(TestCase):
             # he doesn't see BAR, BAZ and SPAM because he doesn't own them
             # and no permission has been given
             self.assertEquals(
-                set(folder.pk for folder, folder_perms in item_list),
+                set(folder.pk for folder in item_list),
                 set([self.foo_folder.pk]))
 
     def test_with_permission_given_to_folder(self):
@@ -838,7 +838,7 @@ class FolderListingTest(TestCase):
             item_list = response.context['paginated_items'].object_list
             # user sees 2 folder : FOO, BAR
             self.assertEquals(
-                set(folder.pk for folder, folder_perms in item_list),
+                set(folder.pk for folder in item_list),
                 set([self.foo_folder.pk, self.bar_folder.pk]))
 
     def test_with_permission_given_to_parent_folder(self):
@@ -856,7 +856,7 @@ class FolderListingTest(TestCase):
             item_list = response.context['paginated_items'].object_list
             # user sees all items because he has permissions on the parent folder
             self.assertEquals(
-                set(folder.pk for folder, folder_perms in item_list),
+                set(folder.pk for folder in item_list),
                 set([self.foo_folder.pk, self.bar_folder.pk, self.baz_folder.pk,
                      self.spam_file.pk]))
 


### PR DESCRIPTION
Fixes #868.

Instead of checking to see if we should show the permissions link for all items, only do that check for items that we are displaying.

Adds a template tag that tells us whether we have permission to do an action on the item. This could be moved into Python if we rather, but would mean faffing about with the items inside the page that the paginator gives us, which seemed less Django-ish.