### PR TITLE
size, sha1 and width, height field recalculation overhaul

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -1035,6 +1035,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         file_obj.id = None
         file_obj.save()
         file_obj.folder = destination
+        file_obj._file_data_changed_hint = False  # no need to update size, sha1, etc.
         file_obj.file = file_obj._copy_file(filename)
         file_obj.original_filename = self._generate_new_filename(file_obj.original_filename, suffix)
         file_obj.save()
@@ -1186,7 +1187,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
     def _resize_image(self, image, form_data):
         original_width = float(image.width)
         original_height = float(image.height)
-        thumbnailer = FilerActionThumbnailer(file=image.file.file, name=image.file.name, source_storage=image.file.source_storage, thumbnail_storage=image.file.source_storage)
+        thumbnailer = FilerActionThumbnailer(file=image.file, name=image.file.name, source_storage=image.file.source_storage, thumbnail_storage=image.file.source_storage)
         # This should overwrite the original image
         new_image = thumbnailer.get_thumbnail({
             'size': tuple(int(form_data[d] or 0) for d in ('width', 'height')),
@@ -1195,8 +1196,10 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             'subject_location': image.subject_location,
         })
         image.file.file = new_image.file
-        image.generate_sha1()
-        image.save()  # Also gets new width and height
+        # Since only file data was changed, there is no way for file field to know about the change.
+        # To update size, sha1, width and height fields let's call file_data_changed callback directly.
+        image.file_data_changed()
+        image.save()
 
         subject_location = normalize_subject_location(image.subject_location)
         if subject_location:

--- a/filer/fields/multistorage_file.py
+++ b/filer/fields/multistorage_file.py
@@ -7,6 +7,7 @@ import warnings
 from io import BytesIO
 
 from django.core.files.base import ContentFile
+from django.db.models.fields.files import FileDescriptor
 from django.utils import six
 from easy_thumbnails import fields as easy_thumbnails_fields
 from easy_thumbnails import files as easy_thumbnails_files
@@ -38,6 +39,32 @@ def generate_filename_multistorage(instance, filename):
         return upload_to(instance, filename)
     else:
         return upload_to
+
+
+class MultiStorageFileDescriptor(FileDescriptor):
+    """
+    This is rather similar to Django's ImageFileDescriptor.
+    It calls <field name>_data_changed on model instance when new
+    value is set. The callback is suposed to update fields which
+    are related to file data (like size, checksum, etc.).
+    When this is called from model __init__ (prev_assigned=False),
+    it does nothing because related fields might not have values yet.
+    In such case data_changed callback should be called at the end of model __init__
+    (File.__init__ in this case).
+    """
+    def __set__(self, instance, value):
+        prev_assigned = self.field.name in instance.__dict__
+        previous_file = instance.__dict__.get(self.field.name)
+        super(MultiStorageFileDescriptor, self).__set__(instance, value)
+
+        # To prevent recalculating file data related attributes when we are instantiating
+        # an object from the database, update only if the field had a value before this assignment.
+        # To prevent recalculating upon reassignment of the same file, update only if value is
+        # different than the previous one.
+        if prev_assigned and value != previous_file:
+            callback_attr = '%s_data_changed' % self.field.name
+            if hasattr(instance, callback_attr):
+                getattr(instance, callback_attr)()
 
 
 class MultiStorageFieldFile(ThumbnailerNameMixin,
@@ -97,6 +124,7 @@ class MultiStorageFieldFile(ThumbnailerNameMixin,
 
 class MultiStorageFileField(easy_thumbnails_fields.ThumbnailerField):
     attr_class = MultiStorageFieldFile
+    descriptor_class = MultiStorageFileDescriptor
 
     def __init__(self, verbose_name=None, name=None,
                  storages=None, thumbnail_storages=None, thumbnail_options=None, **kwargs):

--- a/filer/fields/multistorage_file.py
+++ b/filer/fields/multistorage_file.py
@@ -62,7 +62,7 @@ class MultiStorageFileDescriptor(FileDescriptor):
         # To prevent recalculating upon reassignment of the same file, update only if value is
         # different than the previous one.
         if prev_assigned and value != previous_file:
-            callback_attr = '%s_data_changed' % self.field.name
+            callback_attr = '{}_data_changed'.format(self.field.name)
             if hasattr(instance, callback_attr):
                 getattr(instance, callback_attr)()
 

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -56,15 +56,21 @@ class BaseImage(File):
         iext = os.path.splitext(iname)[1].lower()
         return iext in ['.jpg', '.jpeg', '.png', '.gif']
 
+    def file_data_changed(self, post_init=False):
+        attrs_updated = super(BaseImage, self).file_data_changed(post_init=post_init)
+        if attrs_updated:
+            # update image dimensions
+            try:
+                self.file.seek(0)
+                self._width, self._height = PILImage.open(self.file).size
+                self.file.seek(0)
+            except Exception:
+                # probably the image is missing. nevermind.
+                self._width, self._height = None, None
+        return attrs_updated
+
     def save(self, *args, **kwargs):
         self.has_all_mandatory_data = self._check_validity()
-        try:
-            # do this more efficient somehow?
-            self.file.seek(0)
-            self._width, self._height = PILImage.open(self.file).size
-        except Exception:
-            # probably the image is missing. nevermind.
-            pass
         super(BaseImage, self).save(*args, **kwargs)
 
     def _check_validity(self):

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -43,6 +43,8 @@ class FileManager(PolymorphicManager):
 class File(PolymorphicModel, mixins.IconsMixin):
     file_type = 'File'
     _icon = "file"
+    _file_data_changed_hint = None
+
     folder = models.ForeignKey(Folder, verbose_name=_('folder'), related_name='all_files',
         null=True, blank=True)
     file = MultiStorageFileField(_('file'), null=True, blank=True, max_length=255)
@@ -90,9 +92,9 @@ class File(PolymorphicModel, mixins.IconsMixin):
         field value is changed.
         Returns True if data related attributes were updated, False otherwise.
         """
-        if hasattr(self, '_file_data_changed_hint'):
-            data_changed_hint = getattr(self, '_file_data_changed_hint')
-            delattr(self, '_file_data_changed_hint')
+        if self._file_data_changed_hint is not None:
+            data_changed_hint = self._file_data_changed_hint
+            self._file_data_changed_hint = None
             if not data_changed_hint:
                 return False
         if post_init and self._file_size and self.sha1:

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -81,6 +81,35 @@ class File(PolymorphicModel, mixins.IconsMixin):
     def __init__(self, *args, **kwargs):
         super(File, self).__init__(*args, **kwargs)
         self._old_is_public = self.is_public
+        self.file_data_changed(post_init=True)
+
+    def file_data_changed(self, post_init=False):
+        """
+        This is called whenever self.file changes (including initial set in __init__).
+        MultiStorageFileField has a custom descriptor which calls this function when
+        field value is changed.
+        Returns True if data related attributes were updated, False otherwise.
+        """
+        if hasattr(self, '_file_data_changed_hint'):
+            data_changed_hint = getattr(self, '_file_data_changed_hint')
+            delattr(self, '_file_data_changed_hint')
+            if not data_changed_hint:
+                return False
+        if post_init and self._file_size and self.sha1:
+            # When called from __init__, only update if values are empty.
+            # This makes sure that nothing is done when instantiated from db.
+            return False
+        # cache the file size
+        try:
+            self._file_size = self.file.size
+        except:
+            self._file_size = None
+        # generate SHA1 hash
+        try:
+            self.generate_sha1()
+        except Exception:
+            self.sha1 = ''
+        return True
 
     def _move_file(self):
         """
@@ -107,6 +136,8 @@ class File(PolymorphicModel, mixins.IconsMixin):
         # open the file.
         src_file = src_storage.open(src_file_name)
         src_file.open()
+        # hint file_data_changed callback that data is actually unchanged
+        self._file_data_changed_hint = False
         self.file = dst_storage.save(dst_file_name,
             ContentFile(src_file.read()))
         src_storage.delete(src_file_name)
@@ -153,21 +184,9 @@ class File(PolymorphicModel, mixins.IconsMixin):
             pass
         elif issubclass(self.__class__, File):
             self._file_type_plugin_name = self.__class__.__name__
-        # cache the file size
-        # TODO: only do this if needed (depending on the storage backend the whole file will be downloaded)
-        try:
-            self._file_size = self.file.size
-        except:
-            pass
         if self._old_is_public != self.is_public and self.pk:
             self._move_file()
             self._old_is_public = self.is_public
-        # generate SHA1 hash
-        # TODO: only do this if needed (depending on the storage backend the whole file will be downloaded)
-        try:
-            self.generate_sha1()
-        except Exception:
-            pass
         super(File, self).save(*args, **kwargs)
     save.alters_data = True
 


### PR DESCRIPTION
This is a complete rework of part of #500 relating to size, sha1, width and height recalculation. Current implementation is based on how Django's ImageFileField recalculates width, height. Basically, instead of updating these fields in `save()`, they are updated immediately after MultiStorageFileField value is set.

I also improved change detection in descriptor a bit by checking whether field value is actually changed and detecting calls originating from model's `__init__` properly.
