### PR TITLE
Upgrade django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,19 @@ env:
   - TOX_ENV=py27-dj17-thumbs2x
   - TOX_ENV=py27-dj18-thumbs2x
   - TOX_ENV=py27-dj19-thumbs2x
+  - TOX_ENV=py27-dj110-thumbs2x
 
 # python 3.4
   - TOX_ENV=py34-dj16-thumbs2x
   - TOX_ENV=py34-dj17-thumbs2x
   - TOX_ENV=py34-dj18-thumbs2x
   - TOX_ENV=py34-dj19-thumbs2x
+  - TOX_ENV=py34-dj110-thumbs2x
 
 # python 3.5
   - TOX_ENV=py35-dj18-thumbs2x
   - TOX_ENV=py35-dj19-thumbs2x
+  - TOX_ENV=py35-dj110-thumbs2x
 
 # next Django release
   - TOX_ENV=py27-djmaster-thumbs2x

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -3,15 +3,15 @@ from __future__ import absolute_import
 
 import logging
 import os
-
 from distutils.version import LooseVersion
+
 from django import get_version
 from django.db import models
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 from .. import settings as filer_settings
-from ..utils.compatibility import PILImage, GTE_DJANGO_1_10
+from ..utils.compatibility import GTE_DJANGO_1_10, PILImage
 from ..utils.filer_easy_thumbnails import FilerThumbnailer
 from ..utils.pil_exif import get_exif_for_file
 from .filemodels import File

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -174,4 +174,5 @@ class BaseImage(File):
         app_label = 'filer'
         verbose_name = _('image')
         verbose_name_plural = _('images')
+        default_manager_name = 'objects'
         abstract = True

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -11,7 +11,7 @@ from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 from .. import settings as filer_settings
-from ..utils.compatibility import PILImage
+from ..utils.compatibility import PILImage, GTE_DJANGO_1_10
 from ..utils.filer_easy_thumbnails import FilerThumbnailer
 from ..utils.pil_exif import get_exif_for_file
 from .filemodels import File
@@ -176,3 +176,5 @@ class BaseImage(File):
         verbose_name_plural = _('images')
         default_manager_name = 'objects'
         abstract = True
+        if GTE_DJANGO_1_10:
+            default_manager_name = 'objects'

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -174,7 +174,6 @@ class BaseImage(File):
         app_label = 'filer'
         verbose_name = _('image')
         verbose_name_plural = _('images')
-        default_manager_name = 'objects'
         abstract = True
         if GTE_DJANGO_1_10:
             default_manager_name = 'objects'

--- a/filer/models/imagemodels.py
+++ b/filer/models/imagemodels.py
@@ -30,6 +30,7 @@ if not filer_settings.FILER_IMAGE_MODEL:
             app_label = 'filer'
             verbose_name = _('image')
             verbose_name_plural = _('images')
+            default_manager_name = 'objects'
 
         def save(self, *args, **kwargs):
             if self.date_taken is None:

--- a/filer/models/imagemodels.py
+++ b/filer/models/imagemodels.py
@@ -11,6 +11,7 @@ from django.utils.timezone import get_current_timezone, make_aware, now
 from django.utils.translation import ugettext_lazy as _
 
 from .. import settings as filer_settings
+from ..utils.compatibility import GTE_DJANGO_1_10
 from ..utils.loader import load_object
 from .abstract import BaseImage
 
@@ -30,7 +31,8 @@ if not filer_settings.FILER_IMAGE_MODEL:
             app_label = 'filer'
             verbose_name = _('image')
             verbose_name_plural = _('images')
-            default_manager_name = 'objects'
+            if GTE_DJANGO_1_10:
+                default_manager_name = 'objects'
 
         def save(self, *args, **kwargs):
             if self.date_taken is None:

--- a/filer/test_utils/extended_app/models.py
+++ b/filer/test_utils/extended_app/models.py
@@ -12,6 +12,7 @@ class Video(File):
 
     class Meta:
         app_label = 'extended_app'
+        default_manager_name = 'objects'
 
     @classmethod
     def matches_file_type(cls, iname, ifile, request):
@@ -25,3 +26,4 @@ class ExtImage(BaseImage):
 
     class Meta:
         app_label = 'extended_app'
+        default_manager_name = 'objects'

--- a/filer/test_utils/extended_app/models.py
+++ b/filer/test_utils/extended_app/models.py
@@ -5,6 +5,7 @@ import os.path
 
 from filer.models import BaseImage
 from filer.models.filemodels import File
+from filer.utils.compatibility import GTE_DJANGO_1_10
 
 
 class Video(File):
@@ -12,7 +13,8 @@ class Video(File):
 
     class Meta:
         app_label = 'extended_app'
-        default_manager_name = 'objects'
+        if GTE_DJANGO_1_10:
+            default_manager_name = 'objects'
 
     @classmethod
     def matches_file_type(cls, iname, ifile, request):
@@ -26,4 +28,5 @@ class ExtImage(BaseImage):
 
     class Meta:
         app_label = 'extended_app'
-        default_manager_name = 'objects'
+        if GTE_DJANGO_1_10:
+            default_manager_name = 'objects'

--- a/filer/test_utils/urls.py
+++ b/filer/test_utils/urls.py
@@ -5,11 +5,12 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.views.static import serve
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',  # NOQA
+    url(r'^media/(?P<path>.*)$', serve,
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^', include('filer.server.urls')),

--- a/filer/utils/compatibility.py
+++ b/filer/utils/compatibility.py
@@ -25,6 +25,7 @@ LTE_DJANGO_1_6 = django.VERSION < (1, 7)
 LTE_DJANGO_1_7 = django.VERSION < (1, 8)
 LTE_DJANGO_1_8 = django.VERSION < (1, 9)
 LTE_DJANGO_1_9 = django.VERSION < (1, 10)
+GTE_DJANGO_1_10 = django.VERSION >= (1, 10)
 
 
 if not six.PY3:

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ setup(
     author_email='stefan@foulis.ch',
     packages=find_packages(),
     install_requires=(
-        'Django>=1.5,<1.9.999',  # Django is known to use rc versions
+        'Django>=1.5,<1.10.999',  # Django is known to use rc versions
         'easy-thumbnails>=1.0,<2.4',
         'django-mptt>=0.6,<0.9',  # the exact version depends on Django
-        'django_polymorphic>=0.7,<0.9',
+        'django_polymorphic>=0.7,<1.1',
         'Unidecode>=0.04,<0.05',
     ),
     include_package_data=True,

--- a/test_requirements/django-1.10.txt
+++ b/test_requirements/django-1.10.txt
@@ -1,0 +1,6 @@
+django>=1.10,<1.11
+django-mptt>=0.8,<0.9
+djangocms-helper>=0.9.2,<0.10
+coverage
+
+-r base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ envlist =
 ; easy-thumbnails 1.x supports py27 only and has no dj17+ migrations
     py{27}-dj{16}-thumbs1x
 ; easy-thumbanils 2.x supports all current python and django versions
-    py{34,27}-dj{16,17,18,19,master}-thumbs2x
-    py{34,27}-dj{16,17,18,19,master}-custom_image-thumbs2x
+    py{34,27}-dj{16,17,18,19,110,master}-thumbs2x
+    py{34,27}-dj{16,17,18,19,110,master}-custom_image-thumbs2x
 ; python 3.5 is only supported by Django 1.8+
-    py{35}-dj{18,19,master}-thumbs2x
-    py{35}-dj{18,19,master}-custom_image-thumbs2x
+    py{35}-dj{18,19,110,master}-thumbs2x
+    py{35}-dj{18,19,110,master}-custom_image-thumbs2x
 ; frontend tests
     frontend
 
@@ -58,6 +58,7 @@ deps =
     dj17: -rtest_requirements/django-1.7.txt
     dj18: -rtest_requirements/django-1.8.txt
     dj19: -rtest_requirements/django-1.9.txt
+    dj110: -rtest_requirements/django-1.10.txt
     djmaster: -rtest_requirements/django-master.txt
     py26: unittest2
     py26: argparse


### PR DESCRIPTION
Based on #911.

Also, the various compatibility helpers _litter_ the code base. Are we okay to drop Django < 1.8? Obviously in a separate PR. 