### PR TITLE
Fix history link in Django 1.9+

### DIFF
--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -96,7 +96,9 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
 
     def render_change_form(self, request, context, add=False, change=False,
                            form_url='', obj=None):
+        info = self.model._meta.app_label, self.model._meta.model_name
         extra_context = {'show_delete': True,
+                         'history_url': 'admin:%s_%s_history' % info,
                          'is_popup': popup_status(request),
                          'filer_admin_context': AdminContext(request)}
         context.update(extra_context)

--- a/filer/templates/admin/filer/file/change_form.html
+++ b/filer/templates/admin/filer/file/change_form.html
@@ -34,7 +34,7 @@
 {% block object-tools %}
     {% if change and not is_popup %}
         <ul class="object-tools">
-            <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
+            <li><a href="{% url history_url object_id %}" class="historylink">{% trans "History" %}</a></li>
             {% if has_absolute_url %}
                 <li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="viewsitelink">{% trans "View on site" %}</a></li>
             {% endif%}


### PR DESCRIPTION
In Django 1.9 history link is at the same level of the changeview