### PR TITLE
removes arrow in breadcrumbs if no following folder or name

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ CHANGELOG
 * Fixed an issue where links failed to open from django CMS sideframe
 * Fixes object tools placement on image detail page and removed background color and shadow
 * Added edit button to image widget
+* Removed arrow in breadcrumbs if no folder or name follows
 
 
 1.2.5 (2016-09-05)

--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -70,7 +70,9 @@
                 &rsaquo;
                 {{ breadcrumbs_action }}
             {% else %}
-                &rsaquo;
+                {% if not instance.is_root and instance.is_smart_folder %}
+                    &rsaquo;
+                {% endif %}
                 {% if instance.label %}
                     {{ instance.label }}
                 {% else %}


### PR DESCRIPTION
before
<img width="290" alt="screen shot 2016-11-25 at 11 25 02" src="https://cloud.githubusercontent.com/assets/2270884/20622212/10466696-b302-11e6-978b-8643d36b50f8.png">

after
<img width="296" alt="screen shot 2016-11-25 at 11 24 48" src="https://cloud.githubusercontent.com/assets/2270884/20622221/1640bc36-b302-11e6-8bdd-b3c84093e6f5.png">

