### PR TITLE
Fix jQuery loading on file move/copy page with Django 1.9

### DIFF
--- a/filer/templates/admin/filer/folder/choose_copy_destination.html
+++ b/filer/templates/admin/filer/folder/choose_copy_destination.html
@@ -13,7 +13,7 @@
 
 {% block extrahead %}
     {{ block.super }}
-    <script src="{% static 'admin/js/jquery.js' %}"></script>
+    <script src="{% static 'filer/js/libs/jquery.min.js' %}"></script>
     <script src="{% static 'admin/js/jquery.init.js' %}"></script>
     <script type="text/javascript">
         var __jQuery = django.jQuery;

--- a/filer/templates/admin/filer/folder/choose_move_destination.html
+++ b/filer/templates/admin/filer/folder/choose_move_destination.html
@@ -13,7 +13,7 @@
 
 {% block extrahead %}
     {{ block.super }}
-    <script src="{% static 'admin/js/jquery.js' %}"></script>
+    <script src="{% static 'filer/js/libs/jquery.min.js' %}"></script>
     <script src="{% static 'admin/js/jquery.init.js' %}"></script>
     <script type="text/javascript">
         var __jQuery = django.jQuery;


### PR DESCRIPTION
According to [a comment](https://github.com/divio/django-filer/commit/580e65b09809fcc4ffcd33a1756b40d966199146#commitcomment-17782172) left on the commit that introduced the bug, the location of the jquery.js file has changed in Django 1.9 (as stated in the [release notes](https://docs.djangoproject.com/en/1.9/releases/1.9/#miscellaneous)).

This is a severe problem if you use the `ManifestStaticFilesStorage` as it will cause a 500 error on the move and copy pages (`the file admin/js/jquery.js could not be found with django.contrib.staticfiles.storage.ManifestStaticFilesStorage`).