### PR TITLE
Feature request: `get_css_position` filter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ CHANGELOG
 1.2.7 (unreleased)
 ------------------
 
-* 
+* Added 'get_css_position' template filter for background images 
 
 
 1.2.6 (2017-01-13)

--- a/filer/templatetags/filer_image_tags.py
+++ b/filer/templatetags/filer_image_tags.py
@@ -12,6 +12,10 @@ register = Library()
 RE_SIZE = re.compile(r'(\d+)x(\d+)$')
 
 
+def percentage(part, whole):
+    return 100 * float(part) / float(whole)
+
+
 def _recalculate_size(size, index, divisor=0, padding=0,
                       keep_aspect_ratio=False):
     new_one = size[index]
@@ -105,3 +109,19 @@ def divide_xy_by(original_size, divisor):
     size = divide_y_by(size, divisor=divisor)
     return size
 divide_xy_by = register.filter(divide_xy_by)
+
+
+def get_css_position(image):
+    if not image.subject_location:
+        return '50% 50%'
+
+    x, y = image.subject_location.split(',')
+    width = image.width
+    height = image.height
+
+    coords = '{}% {}%'.format(
+        percentage(x, width),
+        percentage(y, height)
+    )
+    return coords
+get_css_position = register.filter(get_css_position)


### PR DESCRIPTION
Often the image has to be used as a background-image for the container
which size is unknown. Usual way of doing it is setting background image
to the container and using `background-size: cover;`. However if you do
that - focal point position won't be respected. With this template tag
you can now do the following:

```
{% load filer_image_tags %}
<div class="hero"
    style="background-image: url({{ image.url }}; background-position: {{ image|get_css_position }};">
    I'm a hero unit
</div>
```

And the image would be positioned correctly.