### PR TITLE
Fix #994 (Canonical URLs computation)

### DIFF
--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -282,9 +282,9 @@ class File(PolymorphicModel, mixins.IconsMixin):
     @property
     def canonical_time(self):
         if settings.USE_TZ:
-            return int((self.uploaded_at - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds())
+            return int((self.uploaded_at - datetime(1970, 1, 1, 1, tzinfo=timezone.utc)).total_seconds())
         else:
-            return int((self.uploaded_at - datetime(1970, 1, 1)).total_seconds())
+            return int((self.uploaded_at - datetime(1970, 1, 1, 1)).total_seconds())
 
     @property
     def canonical_url(self):


### PR DESCRIPTION
Fixes the computation of Canonical URLs to behave as before commit 878cafe.

See issue #994 