### PR TITLE
Fix RemovedInDjango20Warnings

### DIFF
--- a/filer/migrations/0001_initial.py
+++ b/filer/migrations/0001_initial.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
             name='ClipboardItem',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('clipboard', models.ForeignKey(verbose_name='clipboard', to='filer.Clipboard')),
+                ('clipboard', models.ForeignKey(verbose_name='clipboard', to='filer.Clipboard', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'clipboard item',
@@ -73,8 +73,8 @@ class Migration(migrations.Migration):
                 ('rght', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('tree_id', models.PositiveIntegerField(editable=False, db_index=True)),
                 ('level', models.PositiveIntegerField(editable=False, db_index=True)),
-                ('owner', models.ForeignKey(related_name='filer_owned_folders', verbose_name='owner', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
-                ('parent', models.ForeignKey(related_name='children', verbose_name='parent', blank=True, to='filer.Folder', null=True)),
+                ('owner', models.ForeignKey(related_name='filer_owned_folders', verbose_name='owner', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
+                ('parent', models.ForeignKey(related_name='children', verbose_name='parent', blank=True, to='filer.Folder', null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('name',),
@@ -93,9 +93,9 @@ class Migration(migrations.Migration):
                 ('can_edit', models.SmallIntegerField(default=None, null=True, verbose_name='can edit', blank=True, choices=[(1, 'allow'), (0, 'deny')])),
                 ('can_read', models.SmallIntegerField(default=None, null=True, verbose_name='can read', blank=True, choices=[(1, 'allow'), (0, 'deny')])),
                 ('can_add_children', models.SmallIntegerField(default=None, null=True, verbose_name='can add children', blank=True, choices=[(1, 'allow'), (0, 'deny')])),
-                ('folder', models.ForeignKey(verbose_name='folder', blank=True, to='filer.Folder', null=True)),
-                ('group', models.ForeignKey(related_name='filer_folder_permissions', verbose_name='group', blank=True, to='auth.Group', null=True)),
-                ('user', models.ForeignKey(related_name='filer_folder_permissions', verbose_name='user', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('folder', models.ForeignKey(verbose_name='folder', blank=True, to='filer.Folder', null=True, on_delete=models.CASCADE)),
+                ('group', models.ForeignKey(related_name='filer_folder_permissions', verbose_name='group', blank=True, to='auth.Group', null=True, on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(related_name='filer_folder_permissions', verbose_name='user', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'folder permission',
@@ -110,25 +110,25 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='file',
             name='folder',
-            field=models.ForeignKey(related_name='all_files', verbose_name='folder', blank=True, to='filer.Folder', null=True),
+            field=models.ForeignKey(related_name='all_files', verbose_name='folder', blank=True, to='filer.Folder', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='file',
             name='owner',
-            field=models.ForeignKey(related_name='owned_files', verbose_name='owner', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(related_name='owned_files', verbose_name='owner', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='file',
             name='polymorphic_ctype',
-            field=models.ForeignKey(related_name='polymorphic_filer.file_set', editable=False, to='contenttypes.ContentType', null=True),
+            field=models.ForeignKey(related_name='polymorphic_filer.file_set', editable=False, to='contenttypes.ContentType', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='clipboarditem',
             name='file',
-            field=models.ForeignKey(verbose_name='file', to='filer.File'),
+            field=models.ForeignKey(verbose_name='file', to='filer.File', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -140,13 +140,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='clipboard',
             name='user',
-            field=models.ForeignKey(related_name='filer_clipboards', verbose_name='user', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(related_name='filer_clipboards', verbose_name='user', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.CreateModel(
             name='Image',
             fields=[
-                ('file_ptr', models.OneToOneField(serialize=False, auto_created=True, to='filer.File', primary_key=True, parent_link=True)),
+                ('file_ptr', models.OneToOneField(serialize=False, auto_created=True, to='filer.File', primary_key=True, parent_link=True,on_delete=models.CASCADE)),
                 ('_height', models.IntegerField(null=True, blank=True)),
                 ('_width', models.IntegerField(null=True, blank=True)),
                 ('date_taken', models.DateTimeField(verbose_name='date taken', null=True, editable=False, blank=True)),

--- a/filer/migrations/0002_auto_20150606_2003.py
+++ b/filer/migrations/0002_auto_20150606_2003.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='file',
             name='polymorphic_ctype',
-            field=models.ForeignKey(related_name='polymorphic_filer.file_set+', editable=False, to='contenttypes.ContentType', null=True),
+            field=models.ForeignKey(related_name='polymorphic_filer.file_set+', editable=False, to='contenttypes.ContentType', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -39,7 +39,7 @@ class BaseImage(File):
     subject_location = models.CharField(_('subject location'), max_length=64, blank=True,
                                         default='')
     file_ptr = models.OneToOneField(
-        to='filer.File',
+        to='filer.File', parent_link=True,
         related_name='%(app_label)s_%(class)s_file',
         on_delete=models.CASCADE,
     )

--- a/filer/models/clipboardmodels.py
+++ b/filer/models/clipboardmodels.py
@@ -14,7 +14,7 @@ from ..utils.compatibility import python_2_unicode_compatible
 class Clipboard(models.Model):
     user = models.ForeignKey(
         getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
-        verbose_name=_('user'), related_name="filer_clipboards")
+        verbose_name=_('user'), related_name="filer_clipboards", on_delete=models.CASCADE)
     files = models.ManyToManyField(
         'File', verbose_name=_('files'), related_name="in_clipboards",
         through='ClipboardItem')
@@ -39,8 +39,10 @@ class Clipboard(models.Model):
 
 
 class ClipboardItem(models.Model):
-    file = models.ForeignKey('File', verbose_name=_('file'))
-    clipboard = models.ForeignKey(Clipboard, verbose_name=_('clipboard'))
+    file = models.ForeignKey(
+        'File', verbose_name=_('file'), on_delete=models.CASCADE)
+    clipboard = models.ForeignKey(
+        Clipboard, verbose_name=_('clipboard'), on_delete=models.CASCADE)
 
     class Meta(object):
         app_label = 'filer'

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -48,7 +48,7 @@ class File(PolymorphicModel, mixins.IconsMixin):
     _file_data_changed_hint = None
 
     folder = models.ForeignKey(Folder, verbose_name=_('folder'), related_name='all_files',
-        null=True, blank=True)
+        null=True, blank=True, on_delete=models.CASCADE)
     file = MultiStorageFileField(_('file'), null=True, blank=True, max_length=255)
     _file_size = models.IntegerField(_('file size'), null=True, blank=True)
 

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -100,7 +100,7 @@ class Folder(models.Model, mixins.IconsMixin):
     _icon = 'plainfolder'
 
     parent = models.ForeignKey('self', verbose_name=('parent'), null=True, blank=True,
-                               related_name='children')
+                               related_name='children', on_delete=models.CASCADE)
     name = models.CharField(_('name'), max_length=255)
 
     owner = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), verbose_name=_('owner'),
@@ -262,14 +262,15 @@ class FolderPermission(models.Model):
         (DENY, _('deny')),
     )
 
-    folder = models.ForeignKey(Folder, verbose_name=('folder'), null=True, blank=True)
+    folder = models.ForeignKey(Folder, verbose_name=('folder'),
+                               null=True, blank=True, on_delete=models.CASCADE)
 
     type = models.SmallIntegerField(_('type'), choices=TYPES, default=ALL)
     user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
                              related_name="filer_folder_permissions", on_delete=models.SET_NULL,
                              verbose_name=_("user"), blank=True, null=True)
     group = models.ForeignKey(auth_models.Group,
-                              related_name="filer_folder_permissions",
+                              related_name="filer_folder_permissions", on_delete=models.CASCADE,
                               verbose_name=_("group"), blank=True, null=True)
     everybody = models.BooleanField(_("everybody"), default=False)
 


### PR DESCRIPTION
This fixes deprecation warnings shown by Django 1.11. Compatibility with Django 1.8 is kept. There are two more deprecation warnings which require newer Django versions to be fixed so those can wait.