### PR TITLE
Fix travis tests and broken image reference in template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,35 +53,43 @@ matrix:
       language: generic
       python: "2.7"
       env: DJANGO="1.8" SWAP="no"
+      osx_image: xcode7.3
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.9" SWAP="no"
+      osx_image: xcode7.3
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.10" SWAP="no"
+      osx_image: xcode7.3
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.11" SWAP="no"
+      osx_image: xcode7.3
 
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.8" SWAP="yes"
+      osx_image: xcode7.3
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.9" SWAP="yes"
+      osx_image: xcode7.3
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.10" SWAP="yes"
+      osx_image: xcode7.3
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.11" SWAP="yes"
+      osx_image: xcode7.3
 
     - os: linux
       python: "3.4"
@@ -153,7 +161,9 @@ matrix:
       language: generic
       python: "2.7"
       env: DJANGO="1.10" SWAP="yes"
+      osx_image: xcode7.3
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.11" SWAP="yes"
+      osx_image: xcode7.3

--- a/docs/dump_payload.rst
+++ b/docs/dump_payload.rst
@@ -18,7 +18,7 @@ In order to activate this feature, add::
 
 to the projects ``settings.py`` file.
 
-If the content has been dumped together with to payload, the files are restored when using
+If the content has been dumped together with the payload, the files are restored when using
 ``manage.py loaddata``. If the payload is missing, only the meta-data is restored. This is the
 default behavior.
 

--- a/docs/extending_filer.rst
+++ b/docs/extending_filer.rst
@@ -137,7 +137,7 @@ You'll have to provide an admin class for your model; in this case, the admin wi
 
 .. note::
 
-    If you are not already familiar with the django CMS plugin architecture, http://docs.django-cms.org/en/latest/extending_cms/custom_plugins.html#overview will provide an explanation.
+    If you are not already familiar with the django CMS plugin architecture, http://docs.django-cms.org/en/latest/how_to/custom_plugins.html#overview will provide an explanation.
 
 .. code-block:: python
 

--- a/docs/extending_filer.rst
+++ b/docs/extending_filer.rst
@@ -268,8 +268,7 @@ If you added fields in your custom Image model, you have to customize the admin 
 .. code-block:: python
 
     from django.contrib import admin
-    from filer.admin.imageadmin import ImageAdmin
-    from filer.models.imagemodels import Image
+    from filer.admin.imageadmin import ImageAdmin, Image
 
     class CustomImageAdmin(ImageAdmin):
         # your custom code
@@ -289,7 +288,7 @@ If you added fields in your custom Image model, you have to customize the admin 
     )
 
     # Unregister the default admin
-    admin.site.unregister(ImageAdmin)
+    admin.site.unregister(Image)
     # Register your own
     admin.site.register(Image, CustomImageAdmin)
 

--- a/filer/admin/imageadmin.py
+++ b/filer/admin/imageadmin.py
@@ -2,8 +2,9 @@
 from __future__ import absolute_import
 
 from django import forms
+from django.utils.translation import string_concat
 from django.utils.translation import ugettext as _
-from django.utils.translation import string_concat, ugettext_lazy
+from django.utils.translation import ugettext_lazy
 
 from ..settings import FILER_IMAGE_MODEL
 from ..thumbnail_processors import normalize_subject_location

--- a/filer/templates/admin/filer/widgets/admin_folder.html
+++ b/filer/templates/admin/filer/widgets/admin_folder.html
@@ -15,7 +15,7 @@
                 {% trans "Add Folder" %}
             </a>
 
-            <img id="{{ clear_id }}" src="{% static 'admin/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}" class="filerClearer{% if not object %} hidden{% endif %}">
+            <img id="{{ clear_id }}" src="{% static 'filer/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}" class="filerClearer{% if not object %} hidden{% endif %}">
             {{ hidden_input }}
         </span>
     </div>

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     install_requires=(
         'Django>=1.8,<1.11.999',  # Django is known to use rc versions
-        'easy-thumbnails>=2,<2.5',
+        'easy-thumbnails>=2,<3.0',
         'django-mptt>=0.6,<0.9',  # the exact version depends on Django
         'django_polymorphic>=0.7,<1.4',
         'Unidecode>=0.04,<0.05',


### PR DESCRIPTION
As a temporary fix for osx builds (see travis-ci/travis-ci#8829), `osx_image` was set to xcode7.3. 