### PR TITLE
Fix mac os builds

### DIFF
--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -1,1 +1,1 @@
-Pillow>3.0
+Pillow>3.0,!=5.1.0 # pillow 5.1.0 is broken on OS X 10.11 we use on travis


### PR DESCRIPTION
pillow 5.1.0 is broken on OS X 10.11 we use on travis