### PR TITLE
Feature/fix import files command

### DIFF
--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-from optparse import make_option
 
 from django.core.files import File as DjangoFile
 from django.core.management.base import BaseCommand

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -119,7 +119,7 @@ class Command(BaseCommand):
             '--path',
             action='store',
             dest='path',
-            default=False,
+            required=True,
             help='Import files located in the path into django-filer'
         )
 

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -80,7 +80,7 @@ class FileImporter(object):
         This method walk a directory structure and create the
         Folders and Files as they appear.
         """
-        path = path or self.path if self.path is not False else ''
+        path = path or self.path or ''
         base_folder = base_folder or self.base_folder
         # prevent trailing slashes and other inconsistencies on path.
         path = os.path.normpath(upath(path))

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -133,6 +133,5 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        print(options)
         file_importer = FileImporter(**options)
         file_importer.walker()

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -5,7 +5,7 @@ import os
 from optparse import make_option
 
 from django.core.files import File as DjangoFile
-from django.core.management.base import BaseCommand, NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from ...models.filemodels import File
 from ...models.foldermodels import Folder
@@ -81,7 +81,7 @@ class FileImporter(object):
         This method walk a directory structure and create the
         Folders and Files as they appear.
         """
-        path = path or self.path
+        path = path or self.path if self.path is not False else ''
         base_folder = base_folder or self.base_folder
         # prevent trailing slashes and other inconsistencies on path.
         path = os.path.normpath(upath(path))
@@ -108,27 +108,31 @@ class FileImporter(object):
             print(('folder_created #%s / file_created #%s / ' + 'image_created #%s') % (self.folder_created, self.file_created, self.image_created))
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     """
     Import directory structure into the filer ::
 
         manage.py --path=/tmp/assets/images
         manage.py --path=/tmp/assets/news --folder=images
     """
-
-    option_list = BaseCommand.option_list + (
-        make_option('--path',
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--path',
             action='store',
             dest='path',
             default=False,
-            help='Import files located in the path into django-filer'),
-        make_option('--folder',
+            help='Import files located in the path into django-filer'
+        )
+
+        parser.add_argument(
+            '--folder',
             action='store',
             dest='base_folder',
             default=False,
-            help='Specify the destination folder in which the directory structure should be imported'),
-    )
+            help='Specify the destination folder in which the directory structure should be imported'
+        )
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
+        print(options)
         file_importer = FileImporter(**options)
         file_importer.walker()


### PR DESCRIPTION
Update the import_files command so that is does not use deprecated methods and classes.
Works with Django 1.10+
A simple edit to resolve Issue #966 