### PR TITLE
allow django_polymorphic==2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,39 +131,23 @@ matrix:
       python: "3.6"
       env: DJANGO="master" SWAP="yes"
 
-# image model swapping is failing in Django>=1.10
+# image model swapping is failing in Django==1.10 because django_polymorphic 2.0
+# only support Django>=1.11
     - os: linux
       python: "2.7"
       env: DJANGO="1.10" SWAP="yes"
     - os: linux
-      python: "2.7"
-      env: DJANGO="1.11" SWAP="yes"
-    - os: linux
       python: "3.4"
       env: DJANGO="1.10" SWAP="yes"
-    - os: linux
-      python: "3.4"
-      env: DJANGO="1.11" SWAP="yes"
     - os: linux
       python: "3.5"
       env: DJANGO="1.10" SWAP="yes"
     - os: linux
-      python: "3.5"
-      env: DJANGO="1.11" SWAP="yes"
-    - os: linux
       python: "3.6"
       env: DJANGO="1.10" SWAP="yes"
-    - os: linux
-      python: "3.6"
-      env: DJANGO="1.11" SWAP="yes"
 
     - os: osx
       language: generic
       python: "2.7"
       env: DJANGO="1.10" SWAP="yes"
-      osx_image: xcode7.3
-    - os: osx
-      language: generic
-      python: "2.7"
-      env: DJANGO="1.11" SWAP="yes"
       osx_image: xcode7.3

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,6 +26,10 @@ Please make sure you install `Pillow`_ with JPEG and  ZLIB support installed;
 for further information on Pillow installation and its binary dependencies,
 check `Pillow doc`_.
 
+`django-polymorphic`_ version depends on `Django`_ version:
+
+* for `Django`_ >=1.8,<1.11 use `django-polymorphic`_ 1.3
+* for `Django`_ >=1.11 use `django-polymorphic`_ >=2.0
 
 Configuration
 -------------

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'Django>=1.8,<1.11.999',  # Django is known to use rc versions
         'easy-thumbnails>=2,<3.0',
         'django-mptt>=0.6,<0.9',  # the exact version depends on Django
-        'django_polymorphic>=0.7,<1.4',
+        'django_polymorphic>=0.7,<2.1',
         'Unidecode>=0.04,<0.05',
     ),
     include_package_data=True,

--- a/test_requirements/django-1.10.txt
+++ b/test_requirements/django-1.10.txt
@@ -1,6 +1,7 @@
 django>=1.10,<1.11
 django-mptt>=0.8,<0.9
 djangocms-helper>=0.9.2,<0.10
+django_polymorphic==1.3
 coverage
 
 -r base.txt

--- a/test_requirements/django-1.11.txt
+++ b/test_requirements/django-1.11.txt
@@ -1,6 +1,7 @@
 django>=1.11,<2.0
 django-mptt>=0.8,<0.9
 djangocms-helper>=0.9.2,<0.10
+django_polymorphic>=2.0,<2.1
 coverage
 
 -r base.txt

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,6 +1,7 @@
 django>=1.8,<1.9
 django-mptt>=0.7,<0.9
 djangocms-helper>=0.9.2,<0.10
+django_polymorphic==1.3
 coverage
 
 -r base.txt

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -1,6 +1,7 @@
 django>=1.9,<1.10
 django-mptt>=0.8,<0.9
 djangocms-helper>=0.9.2,<0.10
+django_polymorphic==1.3
 coverage
 
 -r base.txt

--- a/test_requirements/django-master.txt
+++ b/test_requirements/django-master.txt
@@ -1,6 +1,7 @@
 git+git://github.com/django/django.git@master#egg=Django
 django-mptt>=0.7,<0.9
 djangocms-helper>=0.9.2,<0.10
+django_polymorphic>=2.0,<2.1
 coverage
 
 -r base.txt


### PR DESCRIPTION
Thing is, that polymorphic 1.3 has nasty bug when swapped models are used (like swapped Image model in filer). See django-polymorphic/django-polymorphic@02330a5ec835b118d67aacf071cc2deef1250829. Unfortunately, the fix is only included in django-polymorphic 2.0 which only supports Django 1.11 and newer. The problem first appeared in Django 1.10, so it is impossible to have polymorphic swapped model with released version of django-polymorphic.
Therefore, for people using swapped image model and Django 1.11, django-polymorphic 2.0 is required.