### PR TITLE
Fix #1035 -- Hide 'Save as new' button

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Enabled django-mptt 0.9
 * Converted QueryDict to dict before manipulating in admin
+* Hide 'Save as new' button in file admin
 
 1.3.2 (2018-04-23)
 ------------------

--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -26,12 +26,6 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
     raw_id_fields = ('owner',)
     readonly_fields = ('sha1', 'display_canonical')
 
-    # save_as hack, because without save_as it is impossible to hide the
-    # save_and_add_another if save_as is False. To show only save_and_continue
-    # and save in the submit row we need save_as=True and in
-    # render_change_form() override add and change to False.
-    save_as = True
-
     form = FileAdminChangeFrom
 
     @classmethod


### PR DESCRIPTION
Remove the hack (as defined by the code comment) so the button is not
visible anymore.

Also, it seems to me that the 'hack' is not needed anymore - if it's still needed, this PR might introduce breaking changes.