### PR TITLE
Widgets do not work under Django 2.x

### DIFF
--- a/filer/static/filer/js/addons/copy-move-files.js
+++ b/filer/static/filer/js/addons/copy-move-files.js
@@ -6,7 +6,14 @@
     to disable submit if there is only one folder to copy
 */
 
-django.jQuery(function ($) {
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
+djQuery(function ($) {
     var destinationOptions = $('#destination').find('option');
     var destinationOptionLength = destinationOptions.length;
     var submit = $('.js-submit-copy-move');

--- a/filer/static/filer/js/addons/dropdown-menu.js
+++ b/filer/static/filer/js/addons/dropdown-menu.js
@@ -7,6 +7,13 @@
  * ======================================================================== */
 'use strict';
 
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 /* global django */
 (function ($) {
 
@@ -181,4 +188,4 @@
         .on('keydown.bs.filer-dropdown.data-api', toggle, Dropdown.prototype.keydown)
         .on('keydown.bs.filer-dropdown.data-api', '.filer-dropdown-menu', Dropdown.prototype.keydown);
 
-})(django.jQuery);
+})(djQuery);

--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -7,8 +7,15 @@ if (Dropzone) {
     Dropzone.autoDiscover = false;
 }
 
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 /* globals Dropzone, django */
-django.jQuery(function ($) {
+djQuery(function ($) {
     var dropzoneTemplateSelector = '.js-filer-dropzone-template';
     var previewImageSelector = '.js-img-preview';
     var dropzoneSelector = '.js-filer-dropzone';

--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -3,15 +3,15 @@
 /* globals Dropzone, django */
 'use strict';
 
-if (Dropzone) {
-    Dropzone.autoDiscover = false;
-}
-
 // as of Django 2.x we need to check where jQuery is
 var djQuery = window.$;
 
 if (django.jQuery) {
     djQuery = django.jQuery;
+}
+
+if (Dropzone) {
+    Dropzone.autoDiscover = false;
 }
 
 /* globals Dropzone, django */

--- a/filer/static/filer/js/addons/focal-point.js
+++ b/filer/static/filer/js/addons/focal-point.js
@@ -4,6 +4,14 @@
 
 var Cl = window.Cl || {};
 /* globals Class, django */
+
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 (function ($) {
     Cl.FocalPoint = new Class({
         options: {
@@ -132,4 +140,4 @@ var Cl = window.Cl || {};
             this.ratio = null;
         }
     });
-})(django.jQuery);
+})(djQuery);

--- a/filer/static/filer/js/addons/popup_handling.js
+++ b/filer/static/filer/js/addons/popup_handling.js
@@ -1,6 +1,13 @@
 'use strict';
 /* global django */
 
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 (function ($) {
     window.dismissPopupAndReload = function (win) {
         document.location.reload();
@@ -43,4 +50,4 @@
         addFolderButton.addClass('hidden');
         win.close();
     };
-})(django.jQuery);
+})(djQuery);

--- a/filer/static/filer/js/addons/table-dropzone.js
+++ b/filer/static/filer/js/addons/table-dropzone.js
@@ -2,6 +2,13 @@
 // This script implements the dropzone settings
 'use strict';
 
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 /* globals Dropzone, Cl, django */
 (function ($) {
     $(function () {
@@ -213,4 +220,4 @@
             });
         }
     });
-})(django.jQuery);
+})(djQuery);

--- a/filer/static/filer/js/addons/toggler.js
+++ b/filer/static/filer/js/addons/toggler.js
@@ -5,6 +5,13 @@
 var Cl = window.Cl || {};
 /* global Class, django */
 
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 (function ($) {
     Cl.Toggler = new Class({
         options: {
@@ -80,4 +87,4 @@ var Cl = window.Cl || {};
             this.link = null;
         }
     });
-})(django.jQuery);
+})(djQuery);

--- a/filer/static/filer/js/addons/upload-button.js
+++ b/filer/static/filer/js/addons/upload-button.js
@@ -2,6 +2,13 @@
 // This script implements the upload button logic
 'use strict';
 
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 /* globals qq, Cl, django */
 (function ($) {
     $(function () {
@@ -132,4 +139,4 @@
             Cl.filerTooltip($);
         }
     });
-})(django.jQuery);
+})(djQuery);

--- a/filer/static/filer/js/addons/widget.js
+++ b/filer/static/filer/js/addons/widget.js
@@ -1,7 +1,14 @@
 'use strict';
 /* global django */
 
-django.jQuery(function ($) {
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
+djQuery(function ($) {
     var filer_clear = function () {
         var clearer = $(this);
         var container = clearer.closest('.filerFile');

--- a/filer/static/filer/js/base.js
+++ b/filer/static/filer/js/base.js
@@ -7,15 +7,15 @@ var Cl = window.Cl || {};
 
 /* globals Mediator, django */
 
-// mediator init
-Cl.mediator = new Mediator();
-
 // as of Django 2.x we need to check where jQuery is
 var djQuery = window.$;
 
 if (django.jQuery) {
     djQuery = django.jQuery;
 }
+
+// mediator init
+Cl.mediator = new Mediator();
 
 (function ($) {
     $(function () {

--- a/filer/static/filer/js/base.js
+++ b/filer/static/filer/js/base.js
@@ -10,6 +10,13 @@ var Cl = window.Cl || {};
 // mediator init
 Cl.mediator = new Mediator();
 
+// as of Django 2.x we need to check where jQuery is
+var djQuery = window.$;
+
+if (django.jQuery) {
+    djQuery = django.jQuery;
+}
+
 (function ($) {
     $(function () {
         var showErrorTimeout;
@@ -200,4 +207,4 @@ Cl.mediator = new Mediator();
 
         }());
     });
-})(django.jQuery);
+})(djQuery);


### PR DESCRIPTION
The initialisation of jQuery has some delay and may still be attached to window.$. To be safe make sure it is found otherwise drag & drop and selecting an image would fail.