### PR TITLE
Fixed: renderer instead of render argument in AdminFileWidget render

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class AdminFileWidget(ForeignKeyRawIdWidget):
     choices = None
 
-    def render(self, name, value, attrs=None, render=None):
+    def render(self, name, value, attrs=None, renderer=None):
         obj = self.obj_for_value(value)
         css_id = attrs.get('id', 'id_image_x')
         related_url = None


### PR DESCRIPTION
Fixed a typo error merged on #1120 .
AdminFileWidget must receive _renderer_ argument instead of _render_.