### PR TITLE
Fixed #1125 - missing validation message for empty file field in file and image widget

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.4.4 (unreleased)
+------------------
+
+* Fixed missing validation message for empty file field in file and image widget (#1125)
+
+
 1.4.3 (2019-01-07)
 ------------------
 

--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -74,13 +74,16 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
         return '&nbsp;<strong>%s</strong>' % truncate_words(obj, 14)
 
     def obj_for_value(self, value):
-        try:
-            key = self.rel.get_related_field().name
-            if LTE_DJANGO_1_8:
-                obj = self.rel.to._default_manager.get(**{key: value})
-            else:
-                obj = self.rel.model._default_manager.get(**{key: value})
-        except ObjectDoesNotExist:
+        if value:
+            try:
+                key = self.rel.get_related_field().name
+                if LTE_DJANGO_1_8:
+                    obj = self.rel.to._default_manager.get(**{key: value})
+                else:
+                    obj = self.rel.model._default_manager.get(**{key: value})
+            except ObjectDoesNotExist:
+                obj = None
+        else:
             obj = None
         return obj
 


### PR DESCRIPTION
Based on issue #1125
