### PR TITLE
Fixed #1129 - missing validation for folder plugin when folder field are empty

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.4.5 (unreleased)
+------------------
+
+* Fixed missing validation message for folder plugin when folder field are empty (#1129)
+
+
 1.4.4 (2019-01-22)
 ------------------
 

--- a/filer/fields/folder.py
+++ b/filer/fields/folder.py
@@ -72,13 +72,16 @@ class AdminFolderWidget(ForeignKeyRawIdWidget):
         return '&nbsp;<strong>%s</strong>' % truncate_words(obj, 14)
 
     def obj_for_value(self, value):
-        try:
-            key = self.rel.get_related_field().name
-            if LTE_DJANGO_1_8:
-                obj = self.rel.to._default_manager.get(**{key: value})
-            else:
-                obj = self.rel.model._default_manager.get(**{key: value})
-        except ObjectDoesNotExist:
+        if value:
+            try:
+                key = self.rel.get_related_field().name
+                if LTE_DJANGO_1_8:
+                    obj = self.rel.to._default_manager.get(**{key: value})
+                else:
+                    obj = self.rel.model._default_manager.get(**{key: value})
+            except ObjectDoesNotExist:
+                obj = None
+        else:
             obj = None
         return obj
 


### PR DESCRIPTION
Based on issue #1129 
