### PR TITLE
bypassing the thumbnailing step for specific file #460

### DIFF
--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -120,7 +120,7 @@ def ajax_upload(request, folder_id=None):
             # clipboard_item.save()
 
             # Try to generate thumbnails.
-            if not file_obj.icons:
+            if not file_obj.icons and not file_obj.extension == 'svg'
                 # There is no point to continue, as we can't generate
                 # thumbnails for this file. Usual reasons: bad format or
                 # filename.
@@ -156,9 +156,10 @@ def ajax_upload(request, folder_id=None):
                     'crop': True,
                     'upscale': True,
                 }
-                thumbnail_180 = file_obj.file.get_thumbnail(
-                    thumbnail_180_options)
-                data['thumbnail_180'] = thumbnail_180.url
+                if not file_obj.icons and not file_obj.extension == 'svg':
+                    thumbnail_180 = file_obj.file.get_thumbnail(
+                        thumbnail_180_options)
+                    data['thumbnail_180'] = thumbnail_180.url
                 data['original_image'] = file_obj.url
             return JsonResponse(data)
         else:

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -120,7 +120,7 @@ def ajax_upload(request, folder_id=None):
             # clipboard_item.save()
 
             # Try to generate thumbnails.
-            if not file_obj.icons and not file_obj.extension == 'svg'
+            if not file_obj.icons and not file_obj.extension == 'svg':
                 # There is no point to continue, as we can't generate
                 # thumbnails for this file. Usual reasons: bad format or
                 # filename.

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -113,6 +113,8 @@ def ajax_upload(request, folder_id=None):
             # Enforce the FILER_IS_PUBLIC_DEFAULT
             file_obj.is_public = filer_settings.FILER_IS_PUBLIC_DEFAULT
             file_obj.folder = folder
+            file_with_thumbs = None
+            data = {}
             file_obj.save()
             # TODO: Deprecated/refactor
             # clipboard_item = ClipboardItem(
@@ -121,49 +123,56 @@ def ajax_upload(request, folder_id=None):
 
             # Try to generate thumbnails.
             if not file_obj.icons:
-                if not file_obj.extension in filer_settings.FILER_FILE_EXTENSION_NOTHUMBS:
+                if file_obj.extension not in filer_settings.FILER_FILE_EXTENSION_NOTHUMBS:
                     # There is no point to continue, as we can't generate
                     # thumbnails for this file. Usual reasons: bad format or
                     # filename.
                     file_obj.delete()
                     # This would be logged in BaseImage._generate_thumbnails()
                     # if FILER_ENABLE_LOGGING is on.
+                    file_with_thumbs = True
                     return JsonResponse(
                         {'error': 'failed to generate icons for file'},
                         status=500,
                     )
-                thumbnail = None
-                thumbnail_180 = file_obj.file.get_thumbnail(
-                            thumbnail_180_options)
-                data['thumbnail_180'] = thumbnail_180.url
-                # Backwards compatibility: try to get specific icon size (32px)
-                # first. Then try medium icon size (they are already sorted),
-                # fallback to the first (smallest) configured icon.
-                for size in (['32']
-                            + filer_settings.FILER_ADMIN_ICON_SIZES[1::-1]):
-                    try:
-                        thumbnail = file_obj.icons[size]
-                        break
-                    except KeyError:
-                        continue
+                else:
+                    file_with_thumbs = True
+                if file_with_thumbs:
+                    # Backwards compatibility: try to get specific icon size (32px)
+                    # first. Then try medium icon size (they are already sorted),
+                    # fallback to the first (smallest) configured icon.
+                    thumbnail = None
+                    for size in (['32']
+                                + filer_settings.FILER_ADMIN_ICON_SIZES[1::-1]):
+                        try:
+                            thumbnail = file_obj.icons[size]
+                            break
+                        except KeyError:
+                            continue
 
-                data = {
-                    'thumbnail': thumbnail,
+                    # prepare preview thumbnail
+                    if type(file_obj) == Image:
+                        thumbnail_180_options = {
+                            'size': (180, 180),
+                            'crop': True,
+                            'upscale': True,
+                        }
+
+                        thumbnail_180 = file_obj.file.get_thumbnail(
+                            thumbnail_180_options)
+                        data_thumbs = {
+                            'thumbnail': thumbnail,
+                            'thumbnail_180': thumbnail_180.url
+                        }
+                        data.update(data_thumbs)
+
+                data_common = {
+                    'alt_text': '',
+                    'label': str(file_obj),
+                    'file_id': file_obj.pk,
+                    'original_image': file_obj.url
                 }
-                # prepare preview thumbnail
-                if type(file_obj) == Image:
-                    thumbnail_180_options = {
-                        'size': (180, 180),
-                        'crop': True,
-                        'upscale': True,
-                    }
-                    data_common = {
-                        'alt_text': '',
-                        'label': str(file_obj),
-                        'file_id': file_obj.pk,
-                        'original_image' : file_obj.url,
-                    }
-                    data.update(data_common)
+                data.update(data_common)
                 return JsonResponse(data)
             else:
                 form_errors = '; '.join(['%s: %s' % (

--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -71,7 +71,7 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
             ),
         }
         if file_size_svg_max_4ko:
-            context.update({ 'file_size_svg_max_4ko': file_size_svg_max_4ko })
+            context.update({'file_size_svg_max_4ko': file_size_svg_max_4ko})
         html = render_to_string('admin/filer/widgets/admin_file.html', context)
         return mark_safe(html)
 

--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -29,9 +29,12 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
         obj = self.obj_for_value(value)
         css_id = attrs.get('id', 'id_image_x')
         related_url = None
+        file_size_svg_max_4ko = None
         if value:
             try:
                 file_obj = File.objects.get(pk=value)
+                if file_obj.extension == 'svg' and file_obj._file_size <= 4000:
+                    file_size_svg_max_4ko = True
                 related_url = file_obj.logical_folder.get_admin_directory_listing_url_path()
             except Exception as e:
                 # catch exception and manage it. We can re-raise it for debugging
@@ -67,6 +70,10 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
                 else 'admin/img/icon-deletelink.svg'
             ),
         }
+        if file_size_svg_max_4ko :
+            context.update({
+              'file_size_svg_max_4ko': file_size_svg_max_4ko, 
+            })
         html = render_to_string('admin/filer/widgets/admin_file.html', context)
         return mark_safe(html)
 

--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -70,10 +70,8 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
                 else 'admin/img/icon-deletelink.svg'
             ),
         }
-        if file_size_svg_max_4ko :
-            context.update({
-              'file_size_svg_max_4ko': file_size_svg_max_4ko, 
-            })
+        if file_size_svg_max_4ko:
+            context.update({ 'file_size_svg_max_4ko': file_size_svg_max_4ko })
         html = render_to_string('admin/filer/widgets/admin_file.html', context)
         return mark_safe(html)
 

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -33,7 +33,7 @@ class FileImporter(object):
             iext = os.path.splitext(file_obj.name)[1].lower()
         except:  # noqa
             iext = ''
-        if iext in ['.jpg', '.jpeg', '.png', '.gif']:
+        if iext in ['.jpg', '.jpeg', '.png', '.gif', '.svg']:
             obj, created = Image.objects.get_or_create(
                 original_filename=file_obj.name,
                 file=file_obj,

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -8,7 +8,9 @@ from django.core.management.base import BaseCommand
 
 from ...models.filemodels import File
 from ...models.foldermodels import Folder
-from ...settings import FILER_IMAGE_MODEL, FILER_IS_PUBLIC_DEFAULT, FILER_FILE_EXTENSION_ACCEPTED
+from ...settings import (
+    FILER_FILE_EXTENSION_ACCEPTED, FILER_IMAGE_MODEL, FILER_IS_PUBLIC_DEFAULT,
+)
 from ...utils.compatibility import upath
 from ...utils.loader import load_model
 

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 
 from ...models.filemodels import File
 from ...models.foldermodels import Folder
-from ...settings import FILER_IMAGE_MODEL, FILER_IS_PUBLIC_DEFAULT
+from ...settings import FILER_IMAGE_MODEL, FILER_IS_PUBLIC_DEFAULT, FILER_FILE_EXTENSION_ACCEPTED
 from ...utils.compatibility import upath
 from ...utils.loader import load_model
 
@@ -33,7 +33,7 @@ class FileImporter(object):
             iext = os.path.splitext(file_obj.name)[1].lower()
         except:  # noqa
             iext = ''
-        if iext in filer_settings.FILER_FILE_EXTENSION_ACCEPTED:
+        if iext in FILER_FILE_EXTENSION_ACCEPTED:
             obj, created = Image.objects.get_or_create(
                 original_filename=file_obj.name,
                 file=file_obj,

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -33,7 +33,7 @@ class FileImporter(object):
             iext = os.path.splitext(file_obj.name)[1].lower()
         except:  # noqa
             iext = ''
-        if iext in ['.jpg', '.jpeg', '.png', '.gif', '.svg']:
+        if iext in filer_settings.FILER_FILE_EXTENSION_ACCEPTED:
             obj, created = Image.objects.get_or_create(
                 original_filename=file_obj.name,
                 file=file_obj,

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -53,7 +53,7 @@ class BaseImage(File):
         # doing for me was obscuring errors...
         # --Dave Butler <croepha@gmail.com>
         iext = os.path.splitext(iname)[1].lower()
-        return iext in ['.jpg', '.jpeg', '.png', '.gif', '.svg']
+        return iext in filer_settings.FILER_FILE_EXTENSION_ACCEPTED
 
     def file_data_changed(self, post_init=False):
         attrs_updated = super(BaseImage, self).file_data_changed(post_init=post_init)

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -53,7 +53,7 @@ class BaseImage(File):
         # doing for me was obscuring errors...
         # --Dave Butler <croepha@gmail.com>
         iext = os.path.splitext(iname)[1].lower()
-        return iext in ['.jpg', '.jpeg', '.png', '.gif']
+        return iext in ['.jpg', '.jpeg', '.png', '.gif', '.svg']
 
     def file_data_changed(self, post_init=False):
         attrs_updated = super(BaseImage, self).file_data_changed(post_init=post_init)
@@ -92,7 +92,7 @@ class BaseImage(File):
         if hasattr(self, '_exif_cache'):
             return self._exif_cache
         else:
-            if self.file:
+            if hasattr(self.file, 'exif'):
                 self._exif_cache = get_exif_for_file(self.file)
             else:
                 self._exif_cache = {}

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -254,4 +254,5 @@ FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether t
 
 FILER_CANONICAL_URL = getattr(settings, 'FILER_CANONICAL_URL', 'canonical/')
 
-FILER_FILE_EXTENSION_NOTHUMBS =  getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', '.svg','.gltf' )
+FILER_FILE_EXTENSION_ACCEPTED = ['.jpg', '.jpeg', '.png', '.gif', '.svg', ,'.gltf']
+FILER_FILE_EXTENSION_NOTHUMBS =  getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', ['.svg' ,'.gltf']   )

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -253,3 +253,5 @@ FILER_UPLOADER_CONNECTIONS = getattr(
 FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether the filer shall dump the files payload
 
 FILER_CANONICAL_URL = getattr(settings, 'FILER_CANONICAL_URL', 'canonical/')
+
+FILER_FILE_EXTENSION_NOTHUMBS =  getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', '.svg','.gltf' )

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -254,5 +254,5 @@ FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether t
 
 FILER_CANONICAL_URL = getattr(settings, 'FILER_CANONICAL_URL', 'canonical/')
 
-FILER_FILE_EXTENSION_ACCEPTED = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.gltf']
-FILER_FILE_EXTENSION_NOTHUMBS = getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', ['.svg', '.gltf'])
+FILER_FILE_EXTENSION_ACCEPTED = ['.jpg', '.jpeg', '.png', '.gif', '.svg']
+FILER_FILE_EXTENSION_NOTHUMBS = getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', ['.svg'])

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -254,5 +254,5 @@ FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether t
 
 FILER_CANONICAL_URL = getattr(settings, 'FILER_CANONICAL_URL', 'canonical/')
 
-FILER_FILE_EXTENSION_ACCEPTED = ['.jpg', '.jpeg', '.png', '.gif', '.svg', ,'.gltf']
+FILER_FILE_EXTENSION_ACCEPTED = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.gltf']
 FILER_FILE_EXTENSION_NOTHUMBS =  getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', ['.svg' ,'.gltf']   )

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -255,4 +255,4 @@ FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether t
 FILER_CANONICAL_URL = getattr(settings, 'FILER_CANONICAL_URL', 'canonical/')
 
 FILER_FILE_EXTENSION_ACCEPTED = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.gltf']
-FILER_FILE_EXTENSION_NOTHUMBS =  getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', ['.svg' ,'.gltf']   )
+FILER_FILE_EXTENSION_NOTHUMBS = getattr(settings, 'FILER_FILE_EXTENSION_NOTHUMBS', ['.svg', '.gltf'])

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -30,6 +30,9 @@
                         <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{{ object.label }}">
                         &nbsp;<span class="description_text" title="{% trans 'Thumbail is not available for this file.' %}">{% trans 'Thumbail is not available for this file.' %}</span>
                     {% endif %}
+                {% elif object.extension == "gltf" %}
+                        <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{{ object.label }}">
+                        &nbsp;<span class="description_text" title="{% trans 'Thumbail is not available for this file.' %}">{% trans 'Thumbail is not available for this file.' %}</span>
                 {% else %}
                     <img class="thumbnail_img" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
                     &nbsp;<span class="description_text" title="{% trans 'file missing' %}">{% trans 'file missing' %}</span>

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -22,6 +22,8 @@
                 {% if object.icons.32 %}
                     <a href="{{ object.url }}" target="_blank"><img class="thumbnail_img" src="{{ object.icons.48 }}" alt="{{ object.label }}"></a>
                     &nbsp;<span class="description_text" title="{{ object.label }}">{{ object.label }}</span>
+                {% elif object.extension == "svg" %}
+                <img class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}"> 
                 {% else %}
                     <img class="thumbnail_img" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
                     &nbsp;<span class="description_text" title="{% trans 'file missing' %}">{% trans 'file missing' %}</span>

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -23,7 +23,12 @@
                     <a href="{{ object.url }}" target="_blank"><img class="thumbnail_img" src="{{ object.icons.48 }}" alt="{{ object.label }}"></a>
                     &nbsp;<span class="description_text" title="{{ object.label }}">{{ object.label }}</span>
                 {% elif object.extension == "svg" %}
-                <img class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}"> 
+                    {% if file_size_svg_max_4ko %}
+                <svg class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}"></svg>
+                    {% else %}
+                    <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{% trans 'preview in file not available' %}">
+                    &nbsp;<span class="description_text" title="{% trans 'preview in file not available' %}">{% trans 'preview in file not available' %}</span>
+                    {% endif %}
                 {% else %}
                     <img class="thumbnail_img" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
                     &nbsp;<span class="description_text" title="{% trans 'file missing' %}">{% trans 'file missing' %}</span>

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -24,7 +24,7 @@
                     &nbsp;<span class="description_text" title="{{ object.label }}">{{ object.label }}</span>
                 {% elif object.extension == "svg" %}
                     {% if file_size_svg_max_4ko %}
-                        <svg class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}"></svg>
+                        <img class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}">
                     {% else %}
                         <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{% trans 'preview in file not available' %}">
                         &nbsp;<span class="description_text" title="{% trans 'preview in file not available' %}">{% trans 'preview in file not available' %}</span>

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -25,9 +25,10 @@
                 {% elif object.extension == "svg" %}
                     {% if file_size_svg_max_4ko %}
                         <img class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}">
+                        &nbsp;<span class="description_text" title="{{ object.label }}">{{ object.label }}</span>
                     {% else %}
-                        <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{% trans 'preview in file not available' %}">
-                        &nbsp;<span class="description_text" title="{% trans 'preview in file not available' %}">{% trans 'preview in file not available' %}</span>
+                        <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{{ object.label }}">
+                        &nbsp;<span class="description_text" title="{% trans 'Thumbail is not available for this file.' %}">{% trans 'Thumbail is not available for this file.' %}</span>
                     {% endif %}
                 {% else %}
                     <img class="thumbnail_img" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -30,9 +30,6 @@
                         <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{{ object.label }}">
                         &nbsp;<span class="description_text" title="{% trans 'Thumbail is not available for this file.' %}">{% trans 'Thumbail is not available for this file.' %}</span>
                     {% endif %}
-                {% elif object.extension == "gltf" %}
-                        <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{{ object.label }}">
-                        &nbsp;<span class="description_text" title="{% trans 'Thumbail is not available for this file.' %}">{% trans 'Thumbail is not available for this file.' %}</span>
                 {% else %}
                     <img class="thumbnail_img" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
                     &nbsp;<span class="description_text" title="{% trans 'file missing' %}">{% trans 'file missing' %}</span>

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -24,10 +24,10 @@
                     &nbsp;<span class="description_text" title="{{ object.label }}">{{ object.label }}</span>
                 {% elif object.extension == "svg" %}
                     {% if file_size_svg_max_4ko %}
-                <svg class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}"></svg>
+                        <svg class="thumbnail_img" src="{{ object.url }}" alt="{{ object.label }}"></svg>
                     {% else %}
-                    <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{% trans 'preview in file not available' %}">
-                    &nbsp;<span class="description_text" title="{% trans 'preview in file not available' %}">{% trans 'preview in file not available' %}</span>
+                        <img class="thumbnail_img" src="{% static 'filer/icons/file_16x16.png' %}" alt="{% trans 'preview in file not available' %}">
+                        &nbsp;<span class="description_text" title="{% trans 'preview in file not available' %}">{% trans 'preview in file not available' %}</span>
                     {% endif %}
                 {% else %}
                     <img class="thumbnail_img" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">


### PR DESCRIPTION
related #460
Give the ability to download any chosen file extension rather than just files where thumbnail creation is possible on the fly.
With this we can add SVG files and we see the thumbnail  if size <=4ko , if not the file has not preview.