### PR TITLE
Refactor all occurences of templatetag staticfiles against static

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ CHANGELOG
 * Removed support for Django <= 1.10
 * Removed outdated files
 * Code alignments with other addons
+* Replace deprectaed templatetag ``staticfiles`` by ``static``.
 
 
 1.5.0 (2019-04-30)

--- a/filer/models/mixins.py
+++ b/filer/models/mixins.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 from ..settings import FILER_ADMIN_ICON_SIZES
 

--- a/filer/templates/admin/filer/base_site.html
+++ b/filer/templates/admin/filer/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/filer/templates/admin/filer/change_form.html
+++ b/filer/templates/admin/filer/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify staticfiles filer_admin_tags %}
+{% load i18n admin_modify static filer_admin_tags %}
 
 {% block breadcrumbs %}
     {% with original as instance %}

--- a/filer/templates/admin/filer/delete_confirmation.html
+++ b/filer/templates/admin/filer/delete_confirmation.html
@@ -1,5 +1,5 @@
 {% extends "admin/delete_confirmation.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 {% block extrastyle %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.css' %}">

--- a/filer/templates/admin/filer/file/change_form.html
+++ b/filer/templates/admin/filer/file/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/filer/change_form.html" %}
-{% load i18n admin_modify staticfiles %}
+{% load i18n admin_modify static %}
 
 {% block extrahead %}
     {{ block.super }}

--- a/filer/templates/admin/filer/folder/change_form.html
+++ b/filer/templates/admin/filer/folder/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify staticfiles filer_admin_tags %}
+{% load i18n admin_modify static filer_admin_tags %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">

--- a/filer/templates/admin/filer/folder/choose_copy_destination.html
+++ b/filer/templates/admin/filer/folder/choose_copy_destination.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 {% block breadcrumbs %}
     {% include "admin/filer/breadcrumbs.html" %}

--- a/filer/templates/admin/filer/folder/choose_images_resize_options.html
+++ b/filer/templates/admin/filer/folder/choose_images_resize_options.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 {% block breadcrumbs %}
     {% include "admin/filer/breadcrumbs.html" %}

--- a/filer/templates/admin/filer/folder/choose_move_destination.html
+++ b/filer/templates/admin/filer/folder/choose_move_destination.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 {% block breadcrumbs %}
     {% include "admin/filer/breadcrumbs.html" %}

--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -1,5 +1,5 @@
 {% extends "admin/filer/base_site.html" %}
-{% load i18n staticfiles filer_admin_tags %}
+{% load i18n static filer_admin_tags %}
 
 {% block extrahead %}
     {{ block.super }}

--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -1,4 +1,4 @@
-{% load i18n l10n admin_list filer_tags filer_admin_tags staticfiles %}
+{% load i18n l10n admin_list filer_tags filer_admin_tags static %}
 <div class="drag-hover-border"></div>
 <section class="navigator{% if is_popup %} navigator-popup{% endif %}">
     <table class="js-filer-dropzone js-filer-dropzone-base navigator-table" id="result_list" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}" data-max-uploader-connections="{{ uploader_connections }}" data-max-file-size="20">

--- a/filer/templates/admin/filer/image/change_form.html
+++ b/filer/templates/admin/filer/image/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/filer/change_form.html" %}
-{% load i18n admin_modify staticfiles %}
+{% load i18n admin_modify static %}
 
 {% block extrahead %}
     {{ block.super }}

--- a/filer/templates/admin/filer/tools/detail_info.html
+++ b/filer/templates/admin/filer/tools/detail_info.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n static %}
 {% if detail %}
     <section class="image-info image-info-detail">
         <div class="image-info-title">

--- a/filer/templates/admin/filer/tools/search_form.html
+++ b/filer/templates/admin/filer/tools/search_form.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles filer_admin_tags %}
+{% load i18n static filer_admin_tags %}
 
 {% if show_result_count %}
     <div class="small quiet filter-files-cancel filer-info-bar">

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -1,4 +1,4 @@
-{% load i18n filer_admin_tags staticfiles %}
+{% load i18n filer_admin_tags static %}
 
 {% spaceless %}
     <div class="dz-preview dz-file-preview hidden js-filer-dropzone-template">

--- a/filer/templates/admin/filer/widgets/admin_folder.html
+++ b/filer/templates/admin/filer/widgets/admin_folder.html
@@ -1,4 +1,4 @@
-{% load i18n filer_admin_tags staticfiles %}
+{% load i18n filer_admin_tags static %}
 
 {% spaceless %}
     <div class="filer-dropzone filer-dropzone-folder">


### PR DESCRIPTION
In recent versions of Django, the templatetag `staticfiles` has been replaced against `static`. Since Django-2.1 there is a deprecation warning that this templatetag will be removed in Django-3.

Even though this pull request is mandatory, I have little hope that it will be merged soon, considering my experience with the maintainers of django-filer, which even ignore to comment other useful pull requests awaiting to be merged.
