### PR TITLE
Use property ‘download’ to reuse original filename

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+unreleased
+==========
+* Add attribute ``download`` to the download link in order to offer the file
+  under its original name.
+
 
 1.6.0 (2019-11-06)
 ==================

--- a/filer/templates/admin/filer/tools/detail_info.html
+++ b/filer/templates/admin/filer/tools/detail_info.html
@@ -17,7 +17,7 @@
                     </div>
                 {% endif %}
                 <div class="text-left">
-                    <a href="{{ original.url }}" target="_blank" class="btn">
+                    <a href="{{ original.url }}" target="_blank" class="btn" download="{{ original.original_filename }}">
                         {% if file %}
                             {% trans "Open file" %}
                         {% else %}


### PR DESCRIPTION
On upload, django-filer renames files so that they are case-insensitive, without spaces and dots. This however is not what a user expects when he wishes to download that file again.

By adding the property [download="..."](https://www.w3schools.com/tags/att_a_download.asp) to the link, we can restore the expected behaviour.