### PR TITLE
Allow latest unidecode version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIREMENTS = [
     'django-mptt>=0.6,<1.0',  # the exact version depends on Django
     'django_polymorphic>=0.7,<2.1',
     'easy-thumbnails>=2,<3.0',
-    'Unidecode>=0.04,<=1.1.1',
+    'Unidecode>=0.04,<1.2',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIREMENTS = [
     'django-mptt>=0.6,<1.0',  # the exact version depends on Django
     'django_polymorphic>=0.7,<2.1',
     'easy-thumbnails>=2,<3.0',
-    'Unidecode>=0.04,<1.1',
+    'Unidecode>=0.04,<=1.1.1',
 ]
 
 


### PR DESCRIPTION
Resolves dependency issue in other projects where Unidecode >= 1.1 is needed.