### PR TITLE
Support for Django 3

### DIFF
--- a/filer/fields/multistorage_file.py
+++ b/filer/fields/multistorage_file.py
@@ -8,7 +8,7 @@ from io import BytesIO
 
 from django.core.files.base import ContentFile
 from django.db.models.fields.files import FileDescriptor
-from django.utils import six
+import six
 
 from easy_thumbnails import fields as easy_thumbnails_fields
 from easy_thumbnails import files as easy_thumbnails_files

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 from django.db import models
-from django.utils import six
+import six
 from django.utils.translation import ugettext_lazy as _
 
 from .. import settings as filer_settings

--- a/filer/models/clipboardmodels.py
+++ b/filer/models/clipboardmodels.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from . import filemodels

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -10,7 +10,7 @@ from django.core.files.base import ContentFile
 from django.db import models
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from .. import settings as filer_settings

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.http import urlquote
 from django.utils.translation import ugettext_lazy as _
 

--- a/filer/models/thumbnailoptionmodels.py
+++ b/filer/models/thumbnailoptionmodels.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/filer/templatetags/filer_image_tags.py
+++ b/filer/templatetags/filer_image_tags.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import re
 
 from django.template import Library
-from django.utils import six
+import six
 
 
 register = Library()

--- a/filer/templatetags/filer_tags.py
+++ b/filer/templatetags/filer_tags.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import math
 
 from django.template import Library
-from django.utils import six
+import six
 
 
 register = Library()

--- a/filer/thumbnail_processors.py
+++ b/filer/thumbnail_processors.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import re
 
-from django.utils import six
+import six
 
 from easy_thumbnails import processors
 

--- a/filer/utils/compatibility.py
+++ b/filer/utils/compatibility.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 
-from django.utils import six
+import six
 from django.utils.functional import keep_lazy
 from django.utils.text import Truncator, format_lazy
 

--- a/filer/utils/loader.py
+++ b/filer/utils/loader.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 
 from importlib import import_module
 
-from django.utils import six
+import six
 
 
 def load_object(import_path):

--- a/filer/utils/model_label.py
+++ b/filer/utils/model_label.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-from django.utils import six
+import six
 
 
 def get_model_label(model):

--- a/filer/utils/recursive_dictionary.py
+++ b/filer/utils/recursive_dictionary.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import
 
-from django.utils import six
+import six
 
 
 __author__ = 'jannis@itisme.org (Jannis Andrija Schnitzer)'

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ from filer import __version__
 
 
 REQUIREMENTS = [
-    'django>=1.11,<3.0',
+    'django>=3.0,<=3.0.2',
     'django-mptt>=0.6,<1.0',  # the exact version depends on Django
-    'django_polymorphic>=0.7,<2.1',
+    'django_polymorphic>=0.7,<=2.1.2',
     'easy-thumbnails>=2,<3.0',
     'Unidecode>=0.04,<1.2',
 ]


### PR DESCRIPTION
django.utils.encoding.python_2_unicode_compatible() - Alias of six.python_2_unicode_compatible().