### PR TITLE
Bumped version to 1.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ CHANGELOG
 =========
 
 
-1.7.0 (unreleased)
+1.7.0 (2020-02-20)
 ==================
 
 * Added Django 3.0 support

--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.6.0'
+__version__ = '1.7.0'
 
 default_app_config = 'filer.apps.FilerConfig'


### PR DESCRIPTION
* Added Django 3.0 support
* Added support for Python 3.8
* Add attribute ``download`` to the download link in order to offer the file
  under its original name.