### PR TITLE
Conditionally load minified jquery vs regular when in DEBUG mode

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -5,6 +5,7 @@ import logging
 import warnings
 
 from django import forms
+from django.conf import settings as django_settings
 from django.contrib.admin.sites import site
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
 from django.core.exceptions import ObjectDoesNotExist
@@ -89,8 +90,9 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
                 'filer/css/admin_filer.css',
             ]
         }
+        jquery = 'admin/js/vendor/jquery/jquery.js' if django_settings.DEBUG else 'admin/js/vendor/jquery/jquery.min.js'
         js = (
-            'admin/js/vendor/jquery/jquery.js',
+            jquery,
             'admin/js/jquery.init.js',
             'filer/js/libs/dropzone.min.js',
             'filer/js/addons/dropzone.init.js',


### PR DESCRIPTION
Internally, Django minifies jQuery when `DEBUG==False` (https://github.com/django/django/blob/335c9c94acf263901fb023404408880245b0c4b4/django/contrib/admin/options.py#L629-L641). When two items in the media list are the same, they get merged and included only once. This is what correctly happens with the jQuery included by filer when `DEBUG==True`. 

However, since the current filer code doesn't add `.min` to jquery when `DEBUG==False`, there will be two instances of jquery in the media list (`jquery.js` and `jquery.min.js`), which means they won't be recognized as the same and jquery will be included twice. This can lead to issues when using packages that install jquery plugins, as the plugins will only be attached to one of the jquery instances and you'll end up with an error of the form:  `Uncaught TypeError: $(...).somePlugin is not a function`