### PR TITLE
fixes #1188 loading jquery.js after jquery.min.js had been loaded

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -5,6 +5,7 @@ import logging
 import warnings
 
 from django import forms
+from django.conf import settings
 from django.contrib.admin.sites import site
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
 from django.core.exceptions import ObjectDoesNotExist
@@ -84,13 +85,14 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
         return obj
 
     class Media(object):
+        extra = '' if settings.DEBUG else '.min'
         css = {
             'all': [
                 'filer/css/admin_filer.css',
             ]
         }
         js = (
-            'admin/js/vendor/jquery/jquery.js',
+            'admin/js/vendor/jquery/jquery%s.js' % extra,
             'admin/js/jquery.init.js',
             'filer/js/libs/dropzone.min.js',
             'filer/js/addons/dropzone.init.js',


### PR DESCRIPTION
Because filer was requesting jquery.js in non-DEBUG instead of jquery.min.js (like django does), both were being included in the Media output. jquery.js was being included after jquery.min.js and more importantly django's jquery.init.js, so it was polluting the global namespace. This was observed in Django 1.11 and may not be a problem on later versions.

The fix simply uses jquery.min.js in non-debug mode.