### PR TITLE
Use dashed name for django-polymorphic in setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ CHANGELOG
 * Dropped support for Django < 2.2
 * Changed the preferred way to do model registration via model inheritance
   and ``mptt.AlreadyRegistered``, which is deprecated since django-mptt 0.4
+* Use dashed name for django-polymorphic dependency in setup.py
 
 
 1.7.1 (2020-04-29)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from filer import __version__
 REQUIREMENTS = [
     'django>=2.2,<4.0',
     'django-mptt>=0.6,<1.0',  # the exact version depends on Django
-    'django_polymorphic>=2,<3.1',
+    'django-polymorphic>=2,<3.1',
     'easy-thumbnails>=2,<3.0',
     'Unidecode>=0.04,<1.2',
 ]


### PR DESCRIPTION
The name with an underscore works, but just looks off in a `requirements.txt`. Also it will create unnecessary diffs when using tools such as [prequ](https://github.com/suutari/prequ) when an other `setup.py` has specified the name with a dash.