### PR TITLE
Bumped version to 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ CHANGELOG
 =========
 
 
-2.0.0 (unreleased)
+2.0.0 (2020-09-03)
 ==================
 
 * Added support for Django 3.1

--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -14,6 +14,6 @@ Release logic:
 10. twine upload dist/django-filer-{new version}.tar.gz
 """
 
-__version__ = '1.7.1'
+__version__ = '2.0.0'
 
 default_app_config = 'filer.apps.FilerConfig'


### PR DESCRIPTION
* Added support for Django 3.1
* Dropped support for Python 2.7 and Python 3.4
* Dropped support for Django < 2.2
* Changed the preferred way to do model registration via model inheritance
  and ``mptt.AlreadyRegistered``, which is deprecated since django-mptt 0.4
* Use dashed name for django-polymorphic dependency in setup.py
