### PR TITLE
fix #1211: On upload MIME-type is not set correctly

### DIFF
--- a/filer/utils/files.py
+++ b/filer/utils/files.py
@@ -32,7 +32,7 @@ def handle_upload(request):
             # This means we shouldn't continue...raise an error.
             raise UploadException("Invalid content length: %r" % content_length)
 
-        mime_type = request.META.get('CONTENT_TYPE', 'application/octet-stream')
+        mime_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
 
         upload_handlers = request.upload_handlers
         for handler in upload_handlers:


### PR DESCRIPTION
This is a quick fix for #1211 (solution 1).
It guesses the MIME-type using the filename suffix, rather than relying on the `Content-Type` sent by the server.
Should be reviewed as soon as possible, because it fixes a blocker bug.